### PR TITLE
feat!: bump MSRV to 1.81

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: -Dwarnings
   RUSTDOCFLAGS: -Dwarnings
-  MSRV: "1.76"
+  MSRV: "1.81"
   SCCACHE_CACHE_SIZE: "10G"
   IROH_FORCE_STAGING_RELAYS: "1"
 
@@ -204,7 +204,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: nightly-2024-05-02
+        toolchain: nightly-2024-11-30
     - name: Install sccache
       uses: mozilla-actions/sccache-action@v0.0.6
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -32,7 +32,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: nightly-2024-05-02
+        toolchain: nightly-2024-11-30
     - name: Install sccache
       uses: mozilla-actions/sccache-action@v0.0.6
 
@@ -68,6 +68,6 @@ jobs:
         comment-id: ${{ steps.fc.outputs.comment-id }}
         body: |
           Documentation for this PR has been generated and is available at: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${{ env.PREVIEW_PATH }}/iroh_gossip/
-          
+
           Last updated: ${{ env.TIMESTAMP }}
         edit-mode: replace

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["arqu <asmir@n0.computer>", "n0 team"]
 repository = "https://github.com/n0-computer/iroh-metrics"
 
 # Sadly this also needs to be updated in .github/workflows/ci.yml
-rust-version = "1.76"
+rust-version = "1.81"
 
 [lints.rust]
 missing_debug_implementations = "warn"


### PR DESCRIPTION
## Description

## Breaking Changes

- MSRV is bumped from `1.76` to `1.81`

## Notes & open questions
<!-- Any notes, remarks or open questions you have to make about the PR. -->
## Change checklist
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.