### PR TITLE
feat: Reduce dependencies, especially with `--no-default-features`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,6 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "once_cell",
  "prometheus-client",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ unused-async = "warn"
 
 [dependencies]
 erased_set = "0.8"
-once_cell = "1.17.0"
 serde = { version = "1", features = ["derive"] }
 struct_iterable = "0.1"
 thiserror = "2.0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,24 +28,33 @@ unused-async = "warn"
 
 [dependencies]
 erased_set = "0.8"
-http-body-util = "0.1.0"
-hyper = { version = "1", features = ["server", "http1"] }
-hyper-util = { version = "0.1.1", features = ["tokio"] }
 once_cell = "1.17.0"
-prometheus-client = { version = "0.22", optional = true }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 struct_iterable = "0.1"
 thiserror = "2.0.6"
-tokio = { version = "1", features = ["rt", "net", "fs"]}
 tracing = "0.1"
+
+# metrics feature
+http-body-util = { version = "0.1.0", optional = true }
+hyper = { version = "1", features = ["server", "http1"], optional = true }
+hyper-util = { version = "0.1.1", features = ["tokio"], optional = true }
+prometheus-client = { version = "0.22", optional = true }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
+tokio = { version = "1", features = ["rt", "net", "fs"], optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["io-util", "sync", "rt", "net", "fs", "macros", "time", "test-util"] }
 
 [features]
 default = ["metrics"]
-metrics = ["prometheus-client"]
+metrics = [
+    "dep:http-body-util",
+    "dep:hyper",
+    "dep:hyper-util",
+    "dep:prometheus-client",
+    "dep:reqwest",
+    "dep:tokio",
+]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,11 +1,11 @@
 use erased_set::ErasedSyncSet;
-use once_cell::sync::OnceCell;
 #[cfg(feature = "metrics")]
 use prometheus_client::{encoding::text::encode, registry::Registry};
+use std::sync::OnceLock;
 #[cfg(not(feature = "metrics"))]
 type Registry = ();
 
-static CORE: OnceCell<Core> = OnceCell::new();
+static CORE: OnceLock<Core> = OnceLock::new();
 
 /// Core is the base metrics struct.
 ///

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,7 +1,8 @@
+use std::sync::OnceLock;
+
 use erased_set::ErasedSyncSet;
 #[cfg(feature = "metrics")]
 use prometheus_client::{encoding::text::encode, registry::Registry};
-use std::sync::OnceLock;
 #[cfg(not(feature = "metrics"))]
 type Registry = ();
 


### PR DESCRIPTION
## Description
<!-- A summary of what this pull request achieves and a rough list of changes. -->
- Replaces `once_cell` dependency with `std::sync::OnceLock`
- Moves `http-body-util`, `hyper`, `hyper-util`, `prometheus-client`, `reqwest` and `tokio` dependencies to `metrics` feature flag. They were unused with `--no-default-features`

## Breaking Changes
<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->
*Technically* semver check is right, and `prometheus-client` was a feature that I removed here, but really it's not an intentional feature and I'm 99% sure nothing has used that before intentionally.

## Change checklist
- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- [x] All breaking changes documented.