### PR TITLE
feat!: Split up the `metrics` feature into `metrics` and `service`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,12 @@ thiserror = "2.0.6"
 tracing = "0.1"
 
 # metrics feature
+prometheus-client = { version = "0.22", optional = true }
+
+# service feature
 http-body-util = { version = "0.1.0", optional = true }
 hyper = { version = "1", features = ["server", "http1"], optional = true }
 hyper-util = { version = "0.1.1", features = ["tokio"], optional = true }
-prometheus-client = { version = "0.22", optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
 tokio = { version = "1", features = ["rt", "net", "fs"], optional = true }
 
@@ -46,11 +48,19 @@ tokio = { version = "1", features = ["io-util", "sync", "rt", "net", "fs", "macr
 
 [features]
 default = ["metrics"]
+# Enables counters and other metrics being tracked.
+# If disabled, all counters return 0. Macros like `inc!` will do nothing.
 metrics = [
+    "dep:prometheus-client",
+]
+# Enables functionality to run a local metrics server that current metrics
+# are served at in prometheus format.
+# Pulls in quite a few libraries to make exposing an HTTP server possible.
+service = [
+    "metrics",
     "dep:http-body-util",
     "dep:hyper",
     "dep:hyper-util",
-    "dep:prometheus-client",
     "dep:reqwest",
     "dep:tokio",
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,14 +2,14 @@
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![cfg_attr(iroh_docsrs, feature(doc_auto_cfg))]
 
-#[cfg(all(feature = "service"))]
+#[cfg(feature = "service")]
 pub mod metrics;
 
 /// Exposes core types and traits
 pub mod core;
 
 /// Exposes iroh metrics
-#[cfg(all(feature = "service"))]
+#[cfg(feature = "service")]
 mod service;
 
 use std::collections::HashMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,20 @@
 //! Metrics library for iroh
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
+#![cfg_attr(iroh_docsrs, feature(doc_auto_cfg))]
 
+#[cfg(all(feature = "service"))]
 pub mod metrics;
 
-/// Expose core types and traits
+/// Exposes core types and traits
 pub mod core;
 
-/// Expose iroh metrics
-#[cfg(feature = "metrics")]
+/// Exposes iroh metrics
+#[cfg(all(feature = "service"))]
 mod service;
 
 use std::collections::HashMap;
 
-/// Reexport to make matching versions easier.
+/// Reexports `struct_iterable` to make matching versions easier.
 pub use struct_iterable;
 
 /// Potential errors from this library.
@@ -26,7 +28,7 @@ pub enum Error {
     Io(#[from] std::io::Error),
 }
 
-/// Increment the given counter or gauge by 1.
+/// Increments the given counter or gauge by 1.
 #[macro_export]
 macro_rules! inc {
     ($m:ty, $f:ident) => {
@@ -34,7 +36,7 @@ macro_rules! inc {
     };
 }
 
-/// Increment the given counter or gauge by `n`.
+/// Increments the given counter or gauge by `n`.
 #[macro_export]
 macro_rules! inc_by {
     ($m:ty, $f:ident, $n:expr) => {
@@ -42,7 +44,7 @@ macro_rules! inc_by {
     };
 }
 
-/// Set the given counter or gauge to `n`.
+/// Sets the given counter or gauge to `n`.
 #[macro_export]
 macro_rules! set {
     ($m:ty, $f:ident, $n:expr) => {
@@ -50,7 +52,7 @@ macro_rules! set {
     };
 }
 
-/// Decrement the given gauge by 1.
+/// Decrements the given gauge by 1.
 #[macro_export]
 macro_rules! dec {
     ($m:ty, $f:ident) => {
@@ -58,7 +60,7 @@ macro_rules! dec {
     };
 }
 
-/// Decrement the given gauge `n`.
+/// Decrements the given gauge `n`.
 #[macro_export]
 macro_rules! dec_by {
     ($m:ty, $f:ident, $n:expr) => {
@@ -66,7 +68,7 @@ macro_rules! dec_by {
     };
 }
 
-/// Parse Prometheus metrics from a string.
+/// Parses Prometheus metrics from a string.
 pub fn parse_prometheus_metrics(data: &str) -> HashMap<String, f64> {
     let mut metrics = HashMap::new();
     for line in data.lines() {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -48,18 +48,14 @@
 //! inc!(Metrics, things_added);
 //! ```
 
-// TODO: move cfg to lib.rs
-#[cfg(feature = "metrics")]
 use std::net::SocketAddr;
 
 /// Start a server to serve the OpenMetrics endpoint.
-#[cfg(feature = "metrics")]
 pub async fn start_metrics_server(addr: SocketAddr) -> std::io::Result<()> {
     crate::service::run(addr).await
 }
 
 /// Start a metrics dumper service.
-#[cfg(feature = "metrics")]
 pub async fn start_metrics_dumper(
     path: std::path::PathBuf,
     interval: std::time::Duration,
@@ -68,7 +64,6 @@ pub async fn start_metrics_dumper(
 }
 
 /// Start a metrics exporter service.
-#[cfg(feature = "metrics")]
 pub async fn start_metrics_exporter(cfg: crate::PushMetricsConfig) {
     crate::service::exporter(
         cfg.endpoint,


### PR DESCRIPTION
## Description

Splits up the `metrics` feature into `metrics` and `service`. Only `metrics` is a default feature flag now.

This also allows compiling to Wasm *with* the `metrics` feature flag.

## Breaking Changes

- The `metrics` feature flag was reduced and some of its functionality split into the `service` feature flag.
  If you used default feature flags and the service functionality specifically, enable the non-default `service` feature flag now.


## Change checklist
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] All breaking changes documented.