### PR TITLE
feat: non-global metrics usage, add metrics sets

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -210,15 +210,15 @@ pub trait Metric: struct_iterable::Iterable + std::fmt::Debug + 'static + Send +
     }
 }
 
-///
+/// Trait for a set of structs implementing [`Metric`].
 pub trait MetricSet {
-    ///
+    /// Returns an iterator of references to structs implmenting [`Metric`].
     fn iter<'a>(&'a self) -> impl IntoIterator<Item = &'a dyn Metric>;
 
-    ///
+    /// Returns the name of this metrics group set.
     fn name(&self) -> &'static str;
 
-    ///
+    /// Register all metrics groups in this set onto a prometheus client registry.
     #[cfg(feature = "metrics")]
     fn register_all(&self, registry: &mut prometheus_client::registry::Registry) {
         let sub_registry = registry.sub_registry_with_prefix(self.name());

--- a/src/core.rs
+++ b/src/core.rs
@@ -210,6 +210,21 @@ pub trait Metric: struct_iterable::Iterable + std::fmt::Debug + 'static + Send +
     }
 }
 
+/// Extension methods for types implementing [`Metric`].
+///
+/// This contains non-dyn-compatible methods, which is why they can't live on the [`Metric`] trait.
+pub trait MetricExt: Metric + Default {
+    /// Create a new instance and register with a registry.
+    #[cfg(feature = "metrics")]
+    fn new(registry: &mut prometheus_client::registry::Registry) -> Self {
+        let m = Self::default();
+        m.register(registry);
+        m
+    }
+}
+
+impl<T> MetricExt for T where T: Metric + Default {}
+
 /// Trait for a set of structs implementing [`Metric`].
 pub trait MetricSet {
     /// Returns an iterator of references to structs implmenting [`Metric`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,9 @@ pub enum Error {
 #[macro_export]
 macro_rules! inc {
     ($m:ty, $f:ident) => {
-        <$m as $crate::core::Metric>::with_metric(|m| m.$f.inc());
+        if let Some(m) = $crate::core::Core::get().and_then(|c| c.get_collector::<$m>()) {
+            m.$f.inc();
+        }
     };
 }
 
@@ -40,7 +42,9 @@ macro_rules! inc {
 #[macro_export]
 macro_rules! inc_by {
     ($m:ty, $f:ident, $n:expr) => {
-        <$m as $crate::core::Metric>::with_metric(|m| m.$f.inc_by($n));
+        if let Some(m) = $crate::core::Core::get().and_then(|c| c.get_collector::<$m>()) {
+            m.$f.inc_by($n);
+        }
     };
 }
 
@@ -56,7 +60,9 @@ macro_rules! set {
 #[macro_export]
 macro_rules! dec {
     ($m:ty, $f:ident) => {
-        <$m as $crate::core::Metric>::with_metric(|m| m.$f.dec());
+        if let Some(m) = $crate::core::Core::get().and_then(|c| c.get_collector::<$m>()) {
+            m.$f.dec();
+        }
     };
 }
 
@@ -64,7 +70,9 @@ macro_rules! dec {
 #[macro_export]
 macro_rules! dec_by {
     ($m:ty, $f:ident, $n:expr) => {
-        <$m as $crate::core::Metric>::with_metric(|m| m.$f.dec_by($n));
+        if let Some(m) = $crate::core::Core::get().and_then(|c| c.get_collector::<$m>()) {
+            m.$f.dec_by($n);
+        }
     };
 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -35,13 +35,15 @@
 //! }
 //!
 //! impl Metric for Metrics {
-//!     fn name() -> &'static str {
+//!     fn name(&self) -> &'static str {
 //!         "my_metrics"
 //!     }
 //! }
 //!
 //! Core::init(|reg, metrics| {
-//!     metrics.insert(Metrics::new(reg));
+//!     let m = Metrics::default();
+//!     m.register(reg);
+//!     metrics.insert(m);
 //! });
 //!
 //! inc_by!(Metrics, things_added, 2);


### PR DESCRIPTION
## Description

* Allow to create structs implementing `Metric` without registering them to the superglobal `Core`
* Allow to optionally register these metrics to a `prometheus_client::registry::Registry`, and/or iterate over the individual metrics items manually
* Add a trait `MetricSet` which can be implemented on structs containing multiple structs that each implement `Metric`. It allows to iterate over metric structs, and each contained metrics item, and provides a method `register_all` to register all contained metrics to a prometheus registry.

This demonstrates how we could expose a `struct EndpointMetrics` from the endpoint, which has multiple metric sets inside, and still provide a straightforward way to both register them on a `prometheus_client::Registry`, and use them manually without `prometheus_client`.

Based on #12 

## Breaking Changes
<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->
## Notes & open questions
<!-- Any notes, remarks or open questions you have to make about the PR. -->
## Change checklist
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.