### PR TITLE
refactor!: make global core optional, add derive macro, add `MetricsGroup` and `MetricsGroupSet` traits, reoganize modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,9 +70,9 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
-version = "1.2.4"
+version = "1.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
+checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
 dependencies = [
  "shlex",
 ]
@@ -770,15 +770,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -926,12 +925,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,9 +1043,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1066,9 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "http"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +450,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "iroh-metrics-derive",
  "prometheus-client",
  "reqwest",
  "serde",
@@ -451,6 +458,17 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "iroh-metrics-derive"
+version = "0.1.0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "struct_iterable_derive",
+ "syn",
 ]
 
 [[package]]
@@ -596,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -680,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,15 +107,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
 
 [[package]]
-name = "erased-serde"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "erased_set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,7 +445,6 @@ dependencies = [
  "prometheus-client",
  "reqwest",
  "serde",
- "struct_iterable",
  "thiserror",
  "tokio",
  "tracing",
@@ -467,7 +457,6 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "struct_iterable_derive",
  "syn",
 ]
 
@@ -947,35 +936,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "struct_iterable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "849a064c6470a650b72e41fa6c057879b68f804d113af92900f27574828e7712"
-dependencies = [
- "struct_iterable_derive",
- "struct_iterable_internal",
-]
-
-[[package]]
-name = "struct_iterable_derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb939ce88a43ea4e9d012f2f6b4cc789deb2db9d47bad697952a85d6978662c"
-dependencies = [
- "erased-serde",
- "proc-macro2",
- "quote",
- "struct_iterable_internal",
- "syn",
-]
-
-[[package]]
-name = "struct_iterable_internal"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9426b2a0c03e6cc2ea8dbc0168dbbf943f88755e409fb91bcb8f6a268305f4a"
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = ["iroh-metrics-derive"]
+
 [package]
 name = "iroh-metrics"
 version = "0.32.0"
@@ -45,6 +48,9 @@ hyper-util = { version = "0.1.1", features = ["tokio"], optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
 tokio = { version = "1", features = ["rt", "net", "fs"], optional = true }
 
+# derive feature
+iroh-metrics-derive = { path = "./iroh-metrics-derive", optional = true }
+
 [dev-dependencies]
 tokio = { version = "1", features = ["io-util", "sync", "rt", "net", "fs", "macros", "time", "test-util"] }
 
@@ -68,6 +74,8 @@ service = [
 ]
 # Enables a global, static metrics collector
 static_core = ["metrics", "dep:erased_set"]
+# Enables the MetricsGroup derive macro
+derive = ["dep:iroh-metrics-derive"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ unused-async = "warn"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
-struct_iterable = "0.1"
 thiserror = "2.0.6"
 tracing = "0.1"
 
@@ -49,7 +48,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 tokio = { version = "1", features = ["rt", "net", "fs"], optional = true }
 
 # derive feature
-iroh-metrics-derive = { path = "./iroh-metrics-derive", optional = true }
+iroh-metrics-derive = { path = "./iroh-metrics-derive" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["io-util", "sync", "rt", "net", "fs", "macros", "time", "test-util"] }
@@ -74,8 +73,6 @@ service = [
 ]
 # Enables a global, static metrics collector
 static_core = ["metrics", "dep:erased_set"]
-# Enables the MetricsGroup derive macro
-derive = ["dep:iroh-metrics-derive"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)"] }
 unused-async = "warn"
 
 [dependencies]
-erased_set = "0.8"
 serde = { version = "1", features = ["derive"] }
 struct_iterable = "0.1"
 thiserror = "2.0.6"
@@ -35,6 +34,9 @@ tracing = "0.1"
 
 # metrics feature
 prometheus-client = { version = "0.22", optional = true }
+
+# static_core feature
+erased_set = { version = "0.8", optional = true }
 
 # service feature
 http-body-util = { version = "0.1.0", optional = true }
@@ -64,6 +66,8 @@ service = [
     "dep:reqwest",
     "dep:tokio",
 ]
+# Enables a global, static metrics collector
+static_core = ["metrics", "dep:erased_set"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/deny.toml
+++ b/deny.toml
@@ -10,7 +10,6 @@ allow = [
     "BSL-1.0",                        # BOSL license
     "ISC",
     "MIT",
-    "OpenSSL",
     "Zlib",
     "MPL-2.0",                        # https://fossa.com/blog/open-source-software-licenses-101-mozilla-public-license-2-0/
     "Unicode-3.0",

--- a/iroh-metrics-derive/Cargo.toml
+++ b/iroh-metrics-derive/Cargo.toml
@@ -10,5 +10,4 @@ proc-macro = true
 heck = "0.5.0"
 proc-macro2 = "1.0.94"
 quote = "1.0.40"
-struct_iterable_derive = "0.1.0"
 syn = "2"

--- a/iroh-metrics-derive/Cargo.toml
+++ b/iroh-metrics-derive/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
-heck = "0.5.0"
-proc-macro2 = "1.0.94"
-quote = "1.0.40"
+heck = "0.5"
+proc-macro2 = "1"
+quote = "1"
 syn = "2"

--- a/iroh-metrics-derive/Cargo.toml
+++ b/iroh-metrics-derive/Cargo.toml
@@ -2,6 +2,10 @@
 name = "iroh-metrics-derive"
 version = "0.1.0"
 edition = "2021"
+description = "derive macros for iroh-metrics"
+license = "MIT OR Apache-2.0"
+authors = ["Frando <franz@n0.computer>", "n0 team"]
+repository = "https://github.com/n0-computer/iroh-metrics"
 
 [lib]
 proc-macro = true

--- a/iroh-metrics-derive/Cargo.toml
+++ b/iroh-metrics-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iroh-metrics-derive"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/iroh-metrics-derive/Cargo.toml
+++ b/iroh-metrics-derive/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "iroh-metrics-derive"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+heck = "0.5.0"
+proc-macro2 = "1.0.94"
+quote = "1.0.40"
+struct_iterable_derive = "0.1.0"
+syn = "2"

--- a/iroh-metrics-derive/src/lib.rs
+++ b/iroh-metrics-derive/src/lib.rs
@@ -32,7 +32,7 @@ fn expand_iterable(input: &DeriveInput) -> Result<proc_macro2::TokenStream, Erro
         let ident = field.ident.as_ref().unwrap();
         let ident_str = ident.to_string();
         match_arms.extend(quote! {
-            #i => Some((#ident_str, &self.#ident as &dyn ::std::any::Any)),
+            #i => Some((#ident_str, &self.#ident as &dyn ::iroh_metrics::Metric)),
         });
     }
 
@@ -42,7 +42,7 @@ fn expand_iterable(input: &DeriveInput) -> Result<proc_macro2::TokenStream, Erro
                 #count
             }
 
-            fn field(&self, n: usize) -> Option<(&'static str, &dyn ::std::any::Any)> {
+            fn field_ref(&self, n: usize) -> Option<(&'static str, &dyn ::iroh_metrics::Metric)> {
                 match n {
                     #match_arms
                     _ => None,

--- a/iroh-metrics-derive/src/lib.rs
+++ b/iroh-metrics-derive/src/lib.rs
@@ -1,0 +1,105 @@
+use heck::ToSnakeCase;
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{
+    Attribute, DeriveInput, Expr, ExprLit, Fields, Lit, Meta, MetaList, MetaNameValue,
+    parse::Parser, parse_macro_input,
+};
+
+#[proc_macro_derive(MetricsGroup, attributes(metrics))]
+pub fn derive_metrics_group(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    impl_metrics(&input).into()
+}
+
+fn impl_metrics(input: &DeriveInput) -> proc_macro2::TokenStream {
+    let name = &input.ident;
+
+    let syn::Data::Struct(data) = &input.data else {
+        panic!("Only structs are supported.")
+    };
+    let Fields::Named(_fields) = &data.fields else {
+        panic!("Only structs with named fields are supported.")
+    };
+
+    let mut fields_impl = quote! {};
+
+    for field in &data.fields {
+        let field_name = field.ident.as_ref().unwrap();
+        let ty = &field.ty;
+        let doc = parse_doc_comment(&field.attrs)
+            .first()
+            .cloned()
+            .unwrap_or_else(|| field_name.to_string());
+        fields_impl = quote! {
+            #fields_impl
+            #field_name: #ty::new(#doc),
+        };
+    }
+
+    let attr_name =
+        parse_metrics_name(&input.attrs).unwrap_or_else(|| name.to_string().to_snake_case());
+
+    quote! {
+        impl Default for #name {
+            fn default() -> Self {
+                Self {
+                    #fields_impl
+                }
+            }
+        }
+
+        impl MetricsGroup for #name {
+            fn name(&self) -> &'static str {
+                #attr_name
+            }
+        }
+    }
+}
+
+fn parse_doc_comment(attrs: &[Attribute]) -> Vec<String> {
+    let mut lines = vec![];
+    for attr in attrs {
+        if let Meta::NameValue(MetaNameValue { path, value, .. }) = &attr.meta {
+            if path.is_ident("doc") {
+                if let Expr::Lit(ExprLit {
+                    lit: Lit::Str(lit_str),
+                    ..
+                }) = value
+                {
+                    lines.push(lit_str.value().trim().to_string());
+                }
+            }
+        }
+    }
+    lines
+}
+
+fn parse_metrics_name(attrs: &[Attribute]) -> Option<String> {
+    for attr in attrs {
+        if let Meta::List(MetaList { path, tokens, .. }) = &attr.meta {
+            if path.is_ident("metrics") {
+                let parser = syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated;
+                if let Ok(parsed) = parser.parse2(tokens.clone()) {
+                    for meta in parsed {
+                        if let Meta::NameValue(MetaNameValue {
+                            path,
+                            value:
+                                Expr::Lit(ExprLit {
+                                    lit: Lit::Str(lit_str),
+                                    ..
+                                }),
+                            ..
+                        }) = meta
+                        {
+                            if path.is_ident("name") {
+                                return Some(lit_str.value());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}

--- a/iroh-metrics-derive/src/lib.rs
+++ b/iroh-metrics-derive/src/lib.rs
@@ -78,7 +78,7 @@ fn impl_metrics(input: &DeriveInput) -> proc_macro2::TokenStream {
         let field_name = field.ident.as_ref().unwrap();
         let ty = &field.ty;
         let doc = parse_doc_comment(&field.attrs)
-            .get(0)
+            .first()
             .cloned()
             .unwrap_or_else(|| field_name.to_string());
         fields_impl = quote! {
@@ -107,7 +107,7 @@ fn impl_metrics(input: &DeriveInput) -> proc_macro2::TokenStream {
     }
 }
 
-fn parse_doc_comment<'a>(attrs: &'a [Attribute]) -> Vec<String> {
+fn parse_doc_comment(attrs: &[Attribute]) -> Vec<String> {
     let mut lines = vec![];
     for attr in attrs {
         if let Meta::NameValue(MetaNameValue { path, value, .. }) = &attr.meta {

--- a/iroh-metrics-derive/src/lib.rs
+++ b/iroh-metrics-derive/src/lib.rs
@@ -123,9 +123,7 @@ fn parse_metrics_attr(attrs: &[Attribute]) -> Result<MetricsAttr, syn::Error> {
                 out.help = Some(parse_lit_str(&meta)?);
                 Ok(())
             } else {
-                Err(meta.error(
-                    "The `metrics` attribute supports only `name` and `help` fields.",
-                ))
+                Err(meta.error("The `metrics` attribute supports only `name` and `help` fields."))
             }
         })?;
     }

--- a/iroh-metrics-derive/src/lib.rs
+++ b/iroh-metrics-derive/src/lib.rs
@@ -60,13 +60,13 @@ fn expand_metrics(input: &DeriveInput) -> Result<proc_macro2::TokenStream, Error
         let field_name = field.ident.as_ref().unwrap();
         let ty = &field.ty;
         let attr = parse_metrics_attr(&field.attrs)?;
-        let description = attr
-            .description
+        let help = attr
+            .help
             .or_else(|| parse_doc_first_line(&field.attrs))
             .unwrap_or_else(|| field_name.to_string());
 
         field_defaults.extend(quote! {
-            #field_name: #ty::new(#description),
+            #field_name: #ty::new(#help),
         });
     }
 
@@ -109,7 +109,7 @@ fn parse_doc_first_line(attrs: &[Attribute]) -> Option<String> {
 #[derive(Default)]
 struct MetricsAttr {
     name: Option<String>,
-    description: Option<String>,
+    help: Option<String>,
 }
 
 fn parse_metrics_attr(attrs: &[Attribute]) -> Result<MetricsAttr, syn::Error> {
@@ -119,12 +119,12 @@ fn parse_metrics_attr(attrs: &[Attribute]) -> Result<MetricsAttr, syn::Error> {
             if meta.path.is_ident("name") {
                 out.name = Some(parse_lit_str(&meta)?);
                 Ok(())
-            } else if meta.path.is_ident("description") {
-                out.description = Some(parse_lit_str(&meta)?);
+            } else if meta.path.is_ident("help") {
+                out.help = Some(parse_lit_str(&meta)?);
                 Ok(())
             } else {
                 Err(meta.error(
-                    "The `metrics` attribute supports only `name` and `description` fields.",
+                    "The `metrics` attribute supports only `name` and `help` fields.",
                 ))
             }
         })?;

--- a/iroh-metrics-derive/src/lib.rs
+++ b/iroh-metrics-derive/src/lib.rs
@@ -37,7 +37,7 @@ fn expand_iterable(input: &DeriveInput) -> Result<proc_macro2::TokenStream, Erro
     }
 
     Ok(quote! {
-        impl ::iroh_metrics::Iterable for #name {
+        impl ::iroh_metrics::iterable::Iterable for #name {
             fn field_count(&self) -> usize {
                 #count
             }

--- a/src/base.rs
+++ b/src/base.rs
@@ -48,9 +48,9 @@ pub trait MetricsGroup:
     }
 }
 
-/// Extension methods for types implementing [`Metric`].
+/// Extension methods for types implementing [`MetricsGroup`].
 ///
-/// This contains non-dyn-compatible methods, which is why they can't live on the [`Metric`] trait.
+/// This contains non-dyn-compatible methods, which is why they can't live on the [`MetricsGroup`] trait.
 pub trait MetricsGroupExt: MetricsGroup + Default {
     /// Create a new instance and register with a registry.
     #[cfg(feature = "metrics")]
@@ -63,9 +63,9 @@ pub trait MetricsGroupExt: MetricsGroup + Default {
 
 impl<T> MetricsGroupExt for T where T: MetricsGroup + Default {}
 
-/// Trait for a set of structs implementing [`Metric`].
+/// Trait for a set of structs implementing [`MetricsGroup`].
 pub trait MetricsGroupSet {
-    /// Returns an iterator of references to structs implementing [`Metric`].
+    /// Returns an iterator of references to structs implementing [`MetricsGroup`].
     fn iter(&self) -> impl IntoIterator<Item = &dyn MetricsGroup>;
 
     /// Returns the name of this metrics group set.

--- a/src/base.rs
+++ b/src/base.rs
@@ -5,7 +5,7 @@ pub use prometheus_client::registry::Registry;
 
 use crate::{
     iterable::{FieldIter, IntoIterable, Iterable},
-    Counter, Gauge, Metric,
+    Metric,
 };
 
 /// Trait for structs containing metric items.
@@ -15,6 +15,7 @@ pub trait MetricsGroup:
     /// Registers all metric items in this metrics group to a [`prometheus_client::registry::Registry`].
     #[cfg(feature = "metrics")]
     fn register(&self, registry: &mut prometheus_client::registry::Registry) {
+        use crate::{Counter, Gauge};
         let sub_registry = registry.sub_registry_with_prefix(self.name());
         for item in self.iter() {
             if let Some(counter) = item.as_any().downcast_ref::<Counter>() {
@@ -107,7 +108,7 @@ pub trait MetricsGroupSet {
 /// All ops are noops then, get always returns 0.
 #[cfg(all(test, not(feature = "metrics")))]
 mod tests {
-    use super::Counter;
+    use crate::Counter;
 
     #[test]
     fn test() {
@@ -121,7 +122,7 @@ mod tests {
 #[cfg(all(test, feature = "metrics"))]
 mod tests {
     use super::*;
-    use crate::{iterable::Iterable, MetricType};
+    use crate::{iterable::Iterable, Counter, Gauge, MetricType};
 
     #[derive(Debug, Clone, Iterable)]
     pub struct FooMetrics {

--- a/src/base.rs
+++ b/src/base.rs
@@ -98,7 +98,22 @@ pub trait HistogramType {
     fn name(&self) -> &'static str;
 }
 
-#[cfg(test)]
+/// Ensure metrics can be used without `metrics` feature.
+/// All ops are noops then, get always returns 0.
+#[cfg(all(test, not(feature = "metrics")))]
+mod tests {
+    use super::Counter;
+
+    #[test]
+    fn test() {
+        let counter = Counter::new("foo");
+        counter.inc();
+        assert_eq!(counter.get(), 0);
+    }
+}
+
+/// Tests with the `metrics` feature,
+#[cfg(all(test, feature = "metrics"))]
 mod tests {
     use struct_iterable::Iterable;
 
@@ -160,7 +175,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "metrics")]
     #[test]
     fn test_metric_description() -> Result<(), Box<dyn std::error::Error>> {
         let metrics = FooMetrics::default();
@@ -176,7 +190,6 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "metrics")]
     #[test]
     fn test_solo_registry() -> Result<(), Box<dyn std::error::Error>> {
         use prometheus_client::encoding::text::encode;
@@ -215,7 +228,6 @@ foo_metric_b_total 2
         Ok(())
     }
 
-    #[cfg(feature = "metrics")]
     #[test]
     fn test_metric_sets() {
         use prometheus_client::encoding::text::encode;

--- a/src/base.rs
+++ b/src/base.rs
@@ -64,7 +64,7 @@ pub struct ValuesIter<'a> {
     inner: std::vec::IntoIter<(&'static str, &'a dyn std::any::Any)>,
 }
 
-impl<'a> Iterator for ValuesIter<'a> {
+impl Iterator for ValuesIter<'_> {
     type Item = MetricItem;
     fn next(&mut self) -> Option<Self::Item> {
         loop {

--- a/src/base.rs
+++ b/src/base.rs
@@ -60,8 +60,8 @@ impl<T> MetricExt for T where T: Metric + Default {}
 
 /// Trait for a set of structs implementing [`Metric`].
 pub trait MetricSet {
-    /// Returns an iterator of references to structs implmenting [`Metric`].
-    fn iter<'a>(&'a self) -> impl IntoIterator<Item = &'a dyn Metric>;
+    /// Returns an iterator of references to structs implementing [`Metric`].
+    fn iter(&self) -> impl IntoIterator<Item = &dyn Metric>;
 
     /// Returns the name of this metrics group set.
     fn name(&self) -> &'static str;
@@ -170,7 +170,7 @@ mod tests {
             "combined"
         }
 
-        fn iter<'a>(&'a self) -> impl IntoIterator<Item = &'a dyn Metric> {
+        fn iter(&self) -> impl IntoIterator<Item = &dyn Metric> {
             [&self.foo as &dyn Metric, &self.bar as &dyn Metric]
         }
     }
@@ -192,8 +192,7 @@ mod tests {
 
     #[test]
     fn test_solo_registry() -> Result<(), Box<dyn std::error::Error>> {
-        use prometheus_client::encoding::text::encode;
-        use prometheus_client::registry::Registry;
+        use prometheus_client::{encoding::text::encode, registry::Registry};
 
         let mut registry = Registry::default();
         let metrics = FooMetrics::default();
@@ -230,8 +229,7 @@ foo_metric_b_total 2
 
     #[test]
     fn test_metric_sets() {
-        use prometheus_client::encoding::text::encode;
-        use prometheus_client::registry::Registry;
+        use prometheus_client::{encoding::text::encode, registry::Registry};
 
         let metrics = CombinedMetrics::default();
         metrics.foo.metric_a.inc();
@@ -257,8 +255,8 @@ foo_metric_b_total 2
 
         // automatic collection and encoding with prometheus_client
         let mut registry = Registry::default();
-        let mut sub = registry.sub_registry_with_prefix("combined");
-        metrics.register(&mut sub);
+        let sub = registry.sub_registry_with_prefix("combined");
+        metrics.register(sub);
         let exp = "# HELP combined_foo_metric_a metric_a.
 # TYPE combined_foo_metric_a counter
 combined_foo_metric_a_total 1

--- a/src/base.rs
+++ b/src/base.rs
@@ -1,4 +1,7 @@
-pub use crate::metrics::{Counter, Gauge};
+#[cfg(feature = "metrics")]
+pub use prometheus_client::registry::Registry;
+
+use crate::metrics::{Counter, Gauge};
 
 /// Description of a group of metrics.
 pub trait Metric: struct_iterable::Iterable + std::fmt::Debug + 'static + Send + Sync {

--- a/src/base.rs
+++ b/src/base.rs
@@ -1,3 +1,5 @@
+use std::any::Any;
+
 #[cfg(feature = "metrics")]
 pub use prometheus_client::registry::Registry;
 
@@ -5,8 +7,6 @@ use crate::{
     metrics::{Counter, Gauge},
     FieldIter, IntoIterable, Iterable, MetricType,
 };
-
-use std::any::Any;
 /// Description of a group of metrics.
 pub trait MetricsGroup:
     Any + Iterable + IntoIterable + std::fmt::Debug + 'static + Send + Sync
@@ -206,9 +206,8 @@ mod tests {
 /// Tests with the `metrics` feature,
 #[cfg(all(test, feature = "metrics"))]
 mod tests {
-    use crate::Iterable;
-
     use super::*;
+    use crate::Iterable;
 
     #[derive(Debug, Clone, Iterable)]
     pub struct FooMetrics {

--- a/src/base.rs
+++ b/src/base.rs
@@ -373,7 +373,7 @@ combined_bar_count_total 10
         use crate::{MetricValue, MetricsGroup};
 
         #[derive(Debug, Clone, MetricsGroup)]
-        #[metrics(name = "my-metrics")]
+        #[metrics_group(name = "my-metrics")]
         struct Metrics {
             /// Counts foos
             ///
@@ -386,16 +386,16 @@ combined_bar_count_total 10
         }
 
         let metrics = Metrics::default();
+        assert_eq!(metrics.name(), "my-metrics");
 
         metrics.foo.inc();
         metrics.bar.inc_by(2);
         metrics.baz.set(3);
 
-        let values: Vec<_> = metrics.values().collect();
-        let foo = values[0];
-        let bar = values[1];
-        let baz = values[2];
-        assert_eq!(metrics.name(), "my-metrics");
+        let mut values = metrics.values();
+        let foo = values.next().unwrap();
+        let bar = values.next().unwrap();
+        let baz = values.next().unwrap();
         assert_eq!(foo.value, MetricValue::Counter(1));
         assert_eq!(foo.name, "foo");
         assert_eq!(foo.description, "Counts foos");
@@ -410,5 +410,7 @@ combined_bar_count_total 10
         struct FooMetrics {}
         let metrics = FooMetrics::default();
         assert_eq!(metrics.name(), "foo_metrics");
+        let mut values = metrics.values();
+        assert_eq!(values.next(), None);
     }
 }

--- a/src/base.rs
+++ b/src/base.rs
@@ -306,7 +306,7 @@ combined_bar_count_total 10
         use crate::{MetricValue, MetricsGroup};
 
         #[derive(Debug, Clone, MetricsGroup)]
-        #[metrics_group(name = "my-metrics")]
+        #[metrics(name = "my-metrics")]
         struct Metrics {
             /// Counts foos
             ///
@@ -314,7 +314,8 @@ combined_bar_count_total 10
             foo: Counter,
             // no description: use field name as description
             bar: Counter,
-            /// Measures baz
+            /// This docstring is not used as prometheus description
+            #[metrics(description = "Measures baz")]
             baz: Gauge,
         }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -210,15 +210,15 @@ pub trait Metric: struct_iterable::Iterable + std::fmt::Debug + 'static + Send +
     }
 }
 
-///
+/// Trait for a set of structs implementing [`Metric`].
 pub trait MetricSet {
-    ///
+    /// Returns an iterator of references to structs implmenting [`Metric`].
     fn iter<'a>(&'a self) -> impl IntoIterator<Item = &'a dyn Metric>;
 
-    ///
+    /// Returns the name of this metrics group set.
     fn name(&self) -> &'static str;
 
-    ///
+    /// Register all metrics groups in this set onto a prometheus client registry.
     #[cfg(feature = "metrics")]
     fn register_all(&self, registry: &mut prometheus_client::registry::Registry) {
         let sub_registry = registry.sub_registry_with_prefix(self.name());

--- a/src/core.rs
+++ b/src/core.rs
@@ -210,6 +210,21 @@ pub trait Metric: struct_iterable::Iterable + std::fmt::Debug + 'static + Send +
     }
 }
 
+/// Extension methods for types implementing [`Metric`].
+///
+/// This contains non-dyn-compatible methods, which is why they can't live on the [`Metric`] trait.
+pub trait MetricExt: Metric + Default {
+    /// Create a new instance and register with a registry.
+    #[cfg(feature = "metrics")]
+    fn new(registry: &mut prometheus_client::registry::Registry) -> Self {
+        let m = Self::default();
+        m.register(registry);
+        m
+    }
+}
+
+impl<T> MetricExt for T where T: Metric + Default {}
+
 /// Trait for a set of structs implementing [`Metric`].
 pub trait MetricSet {
     /// Returns an iterator of references to structs implmenting [`Metric`].

--- a/src/iterable.rs
+++ b/src/iterable.rs
@@ -1,4 +1,11 @@
+//! Traits for iterating over the fields of structs.
+
 use std::fmt;
+
+/// Derives [`Iterable`] for a struct.
+///
+/// [`Iterable`]: ::iroh_metrics::Iterable
+pub use iroh_metrics_derive::Iterable;
 
 /// Trait for iterating over the fields of a struct.
 pub trait Iterable {

--- a/src/iterable.rs
+++ b/src/iterable.rs
@@ -4,7 +4,11 @@ use std::fmt;
 
 /// Derives [`Iterable`] for a struct.
 ///
-/// [`Iterable`]: ::iroh_metrics::Iterable
+/// You can use this derive instead of [`MetricsGroup`] if you want to implement `Default`
+/// and `MetricsGroup` manually, but still use a derived `Iterable` impl.
+///
+/// [`Iterable`]: ::iroh_metrics::iterable::Iterable
+/// [`MetricsGroup`]: ::iroh_metrics::MetricsGroup
 pub use iroh_metrics_derive::Iterable;
 
 use crate::Metric;

--- a/src/iterable.rs
+++ b/src/iterable.rs
@@ -1,0 +1,74 @@
+use std::fmt;
+
+/// Trait for iterating over the fields of a struct.
+pub trait Iterable {
+    /// Returns the number of fields in the struct.
+    fn field_count(&self) -> usize;
+    /// Returns the field name and dyn reference to the field.
+    fn field(&self, n: usize) -> Option<(&'static str, &dyn std::any::Any)>;
+}
+
+impl dyn Iterable {
+    /// Returns an iterator over the fields of the struct.
+    pub fn iter(&self) -> FieldIter<'_> {
+        FieldIter::new(self)
+    }
+}
+
+/// Helper trait to convert from `self` to `dyn Iterable`.
+pub trait IntoIterable {
+    /// Returns `self` as `dyn Iterable`
+    fn as_iterable(&self) -> &dyn Iterable;
+
+    /// Returns an iterator over the fields of the struct.
+    fn iter(&self) -> FieldIter<'_> {
+        FieldIter::new(self.as_iterable())
+    }
+}
+
+impl<T> IntoIterable for T
+where
+    T: Iterable,
+{
+    fn as_iterable(&self) -> &dyn Iterable {
+        self
+    }
+}
+
+/// Iterator over the fields of a struct.
+///
+/// Returned from [`Iterable::iter`] and [`dyn Iterable::dyn_iter`].
+pub struct FieldIter<'a> {
+    pos: usize,
+    inner: &'a dyn Iterable,
+}
+
+impl<'a> fmt::Debug for FieldIter<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "FieldIter")
+    }
+}
+
+impl<'a> FieldIter<'a> {
+    pub(crate) fn new(inner: &'a dyn Iterable) -> Self {
+        Self { pos: 0, inner }
+    }
+}
+impl<'a> Iterator for FieldIter<'a> {
+    type Item = (&'static str, &'a dyn std::any::Any);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.pos == self.inner.field_count() {
+            None
+        } else {
+            let out = self.inner.field(self.pos);
+            self.pos += 1;
+            out
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let n = self.inner.field_count() - self.pos;
+        (n, Some(n))
+    }
+}

--- a/src/iterable.rs
+++ b/src/iterable.rs
@@ -37,13 +37,13 @@ where
 
 /// Iterator over the fields of a struct.
 ///
-/// Returned from [`Iterable::iter`] and [`dyn Iterable::dyn_iter`].
+/// Returned from [`IntoIterable::iter`].
 pub struct FieldIter<'a> {
     pos: usize,
     inner: &'a dyn Iterable,
 }
 
-impl<'a> fmt::Debug for FieldIter<'a> {
+impl fmt::Debug for FieldIter<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "FieldIter")
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,8 @@ pub mod static_core;
 #[cfg(feature = "service")]
 pub mod service;
 
+extern crate self as iroh_metrics;
+
 use std::collections::HashMap;
 
 /// Potential errors from this library.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@
 /// Exposes core types and traits
 mod base;
 pub use base::*;
+#[cfg(feature = "derive")]
+pub use iroh_metrics_derive::MetricsGroup;
 
 mod metrics;
 pub use metrics::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,11 +24,13 @@ pub mod service;
 /// It will generate a [`Default`] impl which expects all fields to be of a type
 /// that has a public `new` method taking a single `&'static str` argument.
 /// The [`Default::default`] method will call each field's `new` method with the
-/// first line of the field's doc comment as argument.
+/// first line of the field's doc comment as argument. Alternatively, you can override
+/// the value passed to `new` by setting a `#[metrics(description = "my description")]`
+/// attribute on the field.
 ///
 /// It will also generate a [`MetricsGroup`] impl. By default, the struct's name,
 /// converted to `camel_case` will be used as the return value of the [`MetricsGroup::name`]
-/// method. The name can be customized by setting a `#[metrics_group(name = "my-name")]` attribute.
+/// method. The name can be customized by setting a `#[metrics(name = "my-name")]` attribute.
 ///
 /// It will also generate a [`Iterable`] impl.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,21 +2,20 @@
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![cfg_attr(iroh_docsrs, feature(doc_auto_cfg))]
 
-#[cfg(feature = "service")]
-pub mod metrics;
-
 /// Exposes core types and traits
 mod base;
 pub use base::*;
 
+mod metrics;
+pub use metrics::*;
+
 #[cfg(feature = "static_core")]
 pub mod static_core;
 
-/// Exposes iroh metrics
 #[cfg(feature = "service")]
 pub mod service;
 
-use std::{collections::HashMap, time::Duration};
+use std::collections::HashMap;
 
 /// Reexports `struct_iterable` to make matching versions easier.
 pub use struct_iterable;
@@ -51,34 +50,4 @@ pub fn parse_prometheus_metrics(data: &str) -> HashMap<String, f64> {
         metrics.insert(metric.to_string(), value.unwrap());
     }
     metrics
-}
-
-/// Configuration for pushing metrics to a remote endpoint.
-#[derive(PartialEq, Eq, Debug, Default, serde::Deserialize, Clone)]
-pub struct PushMetricsConfig {
-    /// The push interval.
-    pub interval: Duration,
-    /// The endpoint url for the push metrics collector.
-    pub endpoint: String,
-    /// The name of the service you're exporting metrics for.
-    ///
-    /// Generally, `metrics_exporter` is good enough for use
-    /// outside of production deployments.
-    pub service_name: String,
-    /// The name of the instance you're exporting metrics for.
-    ///
-    /// This should be device-unique. If not, this will sum up
-    /// metrics from different devices.
-    ///
-    /// E.g. `username-laptop`, `username-phone`, etc.
-    ///
-    /// Another potential scheme with good privacy would be a
-    /// keyed blake3 hash of the secret key. (This gives you
-    /// an identifier that is as unique as a `NodeID`, but
-    /// can't be correlated to `NodeID`s.)
-    pub instance_name: String,
-    /// The username for basic auth for the push metrics collector.
-    pub username: Option<String>,
-    /// The password for basic auth for the push metrics collector.
-    pub password: String,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 //! Metrics library for iroh
+
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![cfg_attr(iroh_docsrs, feature(doc_auto_cfg))]
 
-/// Exposes core types and traits
 mod base;
 pub use base::*;
 
@@ -34,9 +34,7 @@ pub mod service;
 ///
 /// It will also generate a [`Iterable`] impl.
 ///
-/// [`MetricsGroup`]: ::iroh_metrics::MetricsGroup
-/// [`Iterable`]: ::iroh_metrics::Iterable
-/// [`Default`]: ::std::default::Default
+/// [`Iterable`]: iterable::Iterable
 pub use iroh_metrics_derive::MetricsGroup;
 
 // This lets us use the derive metrics in the lib tests within this crate.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,6 @@
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![cfg_attr(iroh_docsrs, feature(doc_auto_cfg))]
 
-pub use iroh_metrics_derive::{Iterable, MetricsGroup};
-
 /// Exposes core types and traits
 mod base;
 pub use base::*;
@@ -11,8 +9,7 @@ pub use base::*;
 mod metrics;
 pub use metrics::*;
 
-mod iterable;
-pub use iterable::*;
+pub mod iterable;
 
 #[cfg(feature = "static_core")]
 pub mod static_core;
@@ -20,6 +17,27 @@ pub mod static_core;
 #[cfg(feature = "service")]
 pub mod service;
 
+/// Derives [`MetricsGroup`], [`Iterable`] and [`Default`] for a struct.
+///
+/// This derive macro only works on structs with named fields.
+///
+/// It will generate a [`Default`] impl which expects all fields to be of a type
+/// that has a public `new` method taking a single `&'static str` argument.
+/// The [`Default::default`] method will call each field's `new` method with the
+/// first line of the field's doc comment as argument.
+///
+/// It will also generate a [`MetricsGroup`] impl. By default, the struct's name,
+/// converted to `camel_case` will be used as the return value of the [`MetricsGroup::name`]
+/// method. The name can be customized by setting a `#[metrics_group(name = "my-name")]` attribute.
+///
+/// It will also generate a [`Iterable`] impl.
+///
+/// [`MetricsGroup`]: ::iroh_metrics::MetricsGroup
+/// [`Iterable`]: ::iroh_metrics::Iterable
+/// [`Default`]: ::std::default::Default
+pub use iroh_metrics_derive::MetricsGroup;
+
+// This lets us use the derive metrics in the lib tests within this crate.
 extern crate self as iroh_metrics;
 
 use std::collections::HashMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,10 +8,9 @@ pub use base::*;
 
 // TODO(frando): remove
 /// deprecated
-pub mod core {
-    pub use crate::{base::*, metrics::*};
-}
-
+// pub mod core {
+//     pub use crate::{base::*, metrics::*};
+// }
 mod metrics;
 pub use metrics::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,7 @@ pub use base::*;
 // TODO(frando): remove
 /// deprecated
 pub mod core {
-    pub use crate::base::*;
-    pub use crate::metrics::*;
+    pub use crate::{base::*, metrics::*};
 }
 
 mod metrics;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,14 +2,17 @@
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![cfg_attr(iroh_docsrs, feature(doc_auto_cfg))]
 
+pub use iroh_metrics_derive::{Iterable, MetricsGroup};
+
 /// Exposes core types and traits
 mod base;
 pub use base::*;
-#[cfg(feature = "derive")]
-pub use iroh_metrics_derive::MetricsGroup;
 
 mod metrics;
 pub use metrics::*;
+
+mod iterable;
+pub use iterable::*;
 
 #[cfg(feature = "static_core")]
 pub mod static_core;
@@ -18,9 +21,6 @@ pub mod static_core;
 pub mod service;
 
 use std::collections::HashMap;
-
-/// Reexports `struct_iterable` to make matching versions easier.
-pub use struct_iterable;
 
 /// Potential errors from this library.
 #[derive(Debug, thiserror::Error)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,11 +6,6 @@
 mod base;
 pub use base::*;
 
-// TODO(frando): remove
-/// deprecated
-// pub mod core {
-//     pub use crate::{base::*, metrics::*};
-// }
 mod metrics;
 pub use metrics::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,13 @@
 mod base;
 pub use base::*;
 
+// TODO(frando): remove
+/// deprecated
+pub mod core {
+    pub use crate::base::*;
+    pub use crate::metrics::*;
+}
+
 mod metrics;
 pub use metrics::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub mod service;
 /// that has a public `new` method taking a single `&'static str` argument.
 /// The [`Default::default`] method will call each field's `new` method with the
 /// first line of the field's doc comment as argument. Alternatively, you can override
-/// the value passed to `new` by setting a `#[metrics(description = "my description")]`
+/// the value passed to `new` by setting a `#[metrics(help = "my help")]`
 /// attribute on the field.
 ///
 /// It will also generate a [`MetricsGroup`] impl. By default, the struct's name,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,9 @@ pub enum Error {
 #[macro_export]
 macro_rules! inc {
     ($m:ty, $f:ident) => {
-        <$m as $crate::core::Metric>::with_metric(|m| m.$f.inc());
+        if let Some(m) = $crate::core::Core::get().and_then(|c| c.get_collector::<$m>()) {
+            m.$f.inc();
+        }
     };
 }
 
@@ -40,7 +42,9 @@ macro_rules! inc {
 #[macro_export]
 macro_rules! inc_by {
     ($m:ty, $f:ident, $n:expr) => {
-        <$m as $crate::core::Metric>::with_metric(|m| m.$f.inc_by($n));
+        if let Some(m) = $crate::core::Core::get().and_then(|c| c.get_collector::<$m>()) {
+            m.$f.inc_by($n);
+        }
     };
 }
 
@@ -56,7 +60,9 @@ macro_rules! set {
 #[macro_export]
 macro_rules! dec {
     ($m:ty, $f:ident) => {
-        <$m as $crate::core::Metric>::with_metric(|m| m.$f.dec());
+        if let Some(m) = $crate::core::Core::get().and_then(|c| c.get_collector::<$m>()) {
+            m.$f.dec();
+        }
     };
 }
 
@@ -64,7 +70,9 @@ macro_rules! dec {
 #[macro_export]
 macro_rules! dec_by {
     ($m:ty, $f:ident, $n:expr) => {
-        <$m as $crate::core::Metric>::with_metric(|m| m.$f.dec_by($n));
+        if let Some(m) = $crate::core::Core::get().and_then(|c| c.get_collector::<$m>()) {
+            m.$f.dec_by($n);
+        }
     };
 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -20,6 +20,7 @@ pub enum MetricType {
 
 /// The value of an individual metric item.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum MetricValue {
     /// A [`Counter`] value.
     Counter(u64),

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -104,34 +104,33 @@ impl Counter {
     }
 
     /// Increases the [`Counter`] by `u64`, returning the previous value.
-    #[cfg(feature = "metrics")]
     pub fn inc_by(&self, v: u64) -> u64 {
-        self.counter.inc_by(v)
+        #[cfg(feature = "metrics")]
+        {
+            self.counter.inc_by(v)
+        }
+        #[cfg(not(feature = "metrics"))]
+        {
+            let _ = v;
+            0
+        }
     }
 
-    /// Sets the [`Counter`] value.
+    /// Sets the [`Counter`] value, returning the previous value.
     ///
     /// Warning: this is not default behavior for a counter that should always be monotonically increasing.
-    #[cfg(feature = "metrics")]
     pub fn set(&self, v: u64) -> u64 {
-        self.counter
-            .inner()
-            .store(v, std::sync::atomic::Ordering::Relaxed);
-        v
-    }
-
-    /// Sets the [`Counter`] value.
-    ///
-    /// Warning: this is not default behavior for a counter that should always be monotonically increasing.
-    #[cfg(not(feature = "metrics"))]
-    pub fn set(&self, _v: u64) -> u64 {
-        0
-    }
-
-    /// Increases the [`Counter`] by `u64`, returning the previous value.
-    #[cfg(not(feature = "metrics"))]
-    pub fn inc_by(&self, _v: u64) -> u64 {
-        0
+        #[cfg(feature = "metrics")]
+        {
+            self.counter
+                .inner()
+                .swap(v, std::sync::atomic::Ordering::Relaxed)
+        }
+        #[cfg(not(feature = "metrics"))]
+        {
+            let _ = v;
+            0
+        }
     }
 
     /// Returns the current value of the [`Counter`].
@@ -194,15 +193,16 @@ impl Gauge {
     }
 
     /// Increases the [`Gauge`] by `i64`, returning the previous value.
-    #[cfg(feature = "metrics")]
     pub fn inc_by(&self, v: i64) -> i64 {
-        self.gauge.inc_by(v)
-    }
-
-    /// Increases the [`Gauge`] by `i64`, returning the previous value.
-    #[cfg(not(feature = "metrics"))]
-    pub fn inc_by(&self, _v: u64) -> u64 {
-        0
+        #[cfg(feature = "metrics")]
+        {
+            self.gauge.inc_by(v)
+        }
+        #[cfg(not(feature = "metrics"))]
+        {
+            let _ = v;
+            0
+        }
     }
 
     /// Decreases the [`Gauge`] by 1, returning the previous value.
@@ -216,43 +216,38 @@ impl Gauge {
     }
 
     /// Decreases the [`Gauge`] by `i64`, returning the previous value.
-    #[cfg(feature = "metrics")]
     pub fn dec_by(&self, v: i64) -> i64 {
-        self.gauge.dec_by(v)
+        #[cfg(feature = "metrics")]
+        {
+            self.gauge.dec_by(v)
+        }
+        #[cfg(not(feature = "metrics"))]
+        {
+            let _ = v;
+            0
+        }
     }
 
-    /// Decreases the [`Gauge`] by `i64`, returning the previous value.
-    #[cfg(not(feature = "metrics"))]
-    pub fn dec_by(&self, _v: u64) -> u64 {
-        0
-    }
-
-    /// Sets the [`Gauge`] value.
-    #[cfg(feature = "metrics")]
+    /// Sets the [`Gauge`] to `v`, returning the previous value.
     pub fn set(&self, v: i64) -> i64 {
-        self.gauge
-            .inner()
-            .store(v, std::sync::atomic::Ordering::Relaxed);
-        v
-    }
-
-    /// Sets the [`Gauge`] value.
-    #[cfg(not(feature = "metrics"))]
-    pub fn set(&self, _v: i64) -> i64 {
-        0
-    }
-
-    /// Returns the [`Gauge`] value.
-    #[cfg(feature = "metrics")]
-    pub fn get(&self) -> i64 {
-        self.gauge
-            .inner()
-            .load(std::sync::atomic::Ordering::Relaxed)
+        #[cfg(feature = "metrics")]
+        {
+            self.gauge.set(v)
+        }
+        #[cfg(not(feature = "metrics"))]
+        {
+            let _ = v;
+            0
+        }
     }
 
     /// Returns the [`Gauge`] value.
-    #[cfg(not(feature = "metrics"))]
     pub fn get(&self) -> i64 {
+        #[cfg(feature = "metrics")]
+        {
+            self.gauge.get()
+        }
+        #[cfg(not(feature = "metrics"))]
         0
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -6,6 +6,15 @@
 //! If the `metrics` feature is disabled, all operations defined on these types are noops,
 //! and the structs don't collect actual data.
 
+/// The types of metrics supported by this crate.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum MetricType {
+    /// A [`Counter].
+    Counter,
+    /// A [`Gauge].
+    Gauge,
+}
+
 /// Open Metrics [`Counter`] to measure discrete events.
 ///
 /// Single monotonically increasing value metric.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,51 +1,166 @@
-//! Metrics collection
+//! This module defines the individual metric types.
 //!
-//! Enables and manages a global registry of metrics.
-//! Divided up into modules, each module has its own metrics.
-//! Starting the metrics service will expose the metrics on a OpenMetrics http endpoint.
+//! If the `metrics` feature is enabled, they contain metric types based on atomics
+//! which can be modified without needing mutable access.
 //!
-//! To enable metrics collection, call `init_metrics()` before starting the service.
-//!
-//! - To increment a **counter**, use the [`crate::inc`] macro with a value.
-//! - To increment a **counter** by 1, use the [`crate::inc_by`] macro.
-//!
-//! To expose the metrics, start the metrics service with `start_metrics_server()`.
-//!
-//! # Example:
-//! ```rust
-//! use iroh_metrics::{
-//!     core::{Core, Counter, Metric},
-//!     inc, inc_by,
-//! };
-//! use struct_iterable::Iterable;
-//!
-//! #[derive(Debug, Clone, Iterable)]
-//! pub struct Metrics {
-//!     pub things_added: Counter,
-//! }
-//!
-//! impl Default for Metrics {
-//!     fn default() -> Self {
-//!         Self {
-//!             things_added: Counter::new(
-//!                 "things_added tracks the number of things we have added",
-//!             ),
-//!         }
-//!     }
-//! }
-//!
-//! impl Metric for Metrics {
-//!     fn name(&self) -> &'static str {
-//!         "my_metrics"
-//!     }
-//! }
-//!
-//! Core::init(|reg, metrics| {
-//!     let m = Metrics::default();
-//!     m.register(reg);
-//!     metrics.insert(m);
-//! });
-//!
-//! inc_by!(Metrics, things_added, 2);
-//! inc!(Metrics, things_added);
-//! ```
+//! If the `metrics` feature is disabled, all operations defined on these types are noops,
+//! and the structs don't collect actual data.
+
+/// Open Metrics [`Counter`] to measure discrete events.
+///
+/// Single monotonically increasing value metric.
+#[derive(Debug, Clone)]
+pub struct Counter {
+    /// The actual prometheus counter.
+    #[cfg(feature = "metrics")]
+    pub counter: prometheus_client::metrics::counter::Counter,
+    /// What this counter measures.
+    pub description: &'static str,
+}
+
+impl Counter {
+    /// Constructs a new counter, based on the given `description`.
+    pub fn new(description: &'static str) -> Self {
+        Counter {
+            #[cfg(feature = "metrics")]
+            counter: Default::default(),
+            description,
+        }
+    }
+
+    /// Increase the [`Counter`] by 1, returning the previous value.
+    pub fn inc(&self) -> u64 {
+        #[cfg(feature = "metrics")]
+        {
+            self.counter.inc()
+        }
+        #[cfg(not(feature = "metrics"))]
+        0
+    }
+
+    /// Increase the [`Counter`] by `u64`, returning the previous value.
+    #[cfg(feature = "metrics")]
+    pub fn inc_by(&self, v: u64) -> u64 {
+        self.counter.inc_by(v)
+    }
+
+    /// Set the [`Counter`] value.
+    /// Warning: this is not default behavior for a counter that should always be monotonically increasing.
+    #[cfg(feature = "metrics")]
+    pub fn set(&self, v: u64) -> u64 {
+        self.counter
+            .inner()
+            .store(v, std::sync::atomic::Ordering::Relaxed);
+        v
+    }
+
+    /// Set the [`Counter`] value.
+    /// Warning: this is not default behavior for a counter that should always be monotonically increasing.
+    #[cfg(not(feature = "metrics"))]
+    pub fn set(&self, _v: u64) -> u64 {
+        0
+    }
+
+    /// Increase the [`Counter`] by `u64`, returning the previous value.
+    #[cfg(not(feature = "metrics"))]
+    pub fn inc_by(&self, _v: u64) -> u64 {
+        0
+    }
+
+    /// Get the current value of the [`Counter`].
+    pub fn get(&self) -> u64 {
+        #[cfg(feature = "metrics")]
+        {
+            self.counter.get()
+        }
+        #[cfg(not(feature = "metrics"))]
+        0
+    }
+}
+
+/// Open Metrics [`Gauge`].
+#[derive(Debug, Clone)]
+pub struct Gauge {
+    /// The actual prometheus gauge.
+    #[cfg(feature = "metrics")]
+    pub gauge: prometheus_client::metrics::gauge::Gauge,
+    /// What this gauge tracks.
+    pub description: &'static str,
+}
+impl Gauge {
+    /// Constructs a new gauge, based on the given `description`.
+    pub fn new(description: &'static str) -> Self {
+        Self {
+            #[cfg(feature = "metrics")]
+            gauge: Default::default(),
+            description,
+        }
+    }
+
+    /// Increase the [`Gauge`] by 1, returning the previous value.
+    pub fn inc(&self) -> i64 {
+        #[cfg(feature = "metrics")]
+        {
+            self.gauge.inc()
+        }
+        #[cfg(not(feature = "metrics"))]
+        0
+    }
+    /// Increase the [`Gauge`] by `i64`, returning the previous value.
+    #[cfg(feature = "metrics")]
+    pub fn inc_by(&self, v: i64) -> i64 {
+        self.gauge.inc_by(v)
+    }
+    /// Increase the [`Gauge`] by `i64`, returning the previous value.
+    #[cfg(not(feature = "metrics"))]
+    pub fn inc_by(&self, _v: u64) -> u64 {
+        0
+    }
+
+    /// Decrease the [`Gauge`] by 1, returning the previous value.
+    pub fn dec(&self) -> i64 {
+        #[cfg(feature = "metrics")]
+        {
+            self.gauge.dec()
+        }
+        #[cfg(not(feature = "metrics"))]
+        0
+    }
+    /// Decrease the [`Gauge`] by `i64`, returning the previous value.
+    #[cfg(feature = "metrics")]
+    pub fn dec_by(&self, v: i64) -> i64 {
+        self.gauge.dec_by(v)
+    }
+    /// Decrease the [`Gauge`] by `i64`, returning the previous value.
+    #[cfg(not(feature = "metrics"))]
+    pub fn dec_by(&self, _v: u64) -> u64 {
+        0
+    }
+
+    /// Set the [`Gauge`] value.
+    #[cfg(feature = "metrics")]
+    pub fn set(&self, v: i64) -> i64 {
+        self.gauge
+            .inner()
+            .store(v, std::sync::atomic::Ordering::Relaxed);
+        v
+    }
+    /// Set the [`Gauge`] value.
+    #[cfg(not(feature = "metrics"))]
+    pub fn set(&self, _v: i64) -> i64 {
+        0
+    }
+
+    /// Get the [`Gauge`] value.
+    #[cfg(feature = "metrics")]
+    pub fn get(&self) -> i64 {
+        self.gauge
+            .inner()
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+    /// Get the [`Gauge`] value.
+    #[cfg(not(feature = "metrics"))]
+    pub fn get(&self) -> i64 {
+        0
+    }
+}

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -35,13 +35,15 @@
 //! }
 //!
 //! impl Metric for Metrics {
-//!     fn name() -> &'static str {
+//!     fn name(&self) -> &'static str {
 //!         "my_metrics"
 //!     }
 //! }
 //!
 //! Core::init(|reg, metrics| {
-//!     metrics.insert(Metrics::new(reg));
+//!     let m = Metrics::default();
+//!     m.register(reg);
+//!     metrics.insert(m);
 //! });
 //!
 //! inc_by!(Metrics, things_added, 2);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -49,31 +49,3 @@
 //! inc_by!(Metrics, things_added, 2);
 //! inc!(Metrics, things_added);
 //! ```
-
-use std::net::SocketAddr;
-
-/// Start a server to serve the OpenMetrics endpoint.
-pub async fn start_metrics_server(addr: SocketAddr) -> std::io::Result<()> {
-    crate::service::run(addr).await
-}
-
-/// Start a metrics dumper service.
-pub async fn start_metrics_dumper(
-    path: std::path::PathBuf,
-    interval: std::time::Duration,
-) -> Result<(), crate::Error> {
-    crate::service::dumper(&path, interval).await
-}
-
-/// Start a metrics exporter service.
-pub async fn start_metrics_exporter(cfg: crate::PushMetricsConfig) {
-    crate::service::exporter(
-        cfg.endpoint,
-        cfg.service_name,
-        cfg.instance_name,
-        cfg.username,
-        cfg.password,
-        std::time::Duration::from_secs(cfg.interval),
-    )
-    .await;
-}

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -46,8 +46,8 @@ pub trait Metric: std::fmt::Debug {
     /// The current value of this metric.
     fn value(&self) -> MetricValue;
 
-    /// The description of this metric.
-    fn description(&self) -> &'static str;
+    /// The help string for this metric.
+    fn help(&self) -> &'static str;
 
     /// Cast this metric to [`Any`] for downcasting to concrete types.
     fn as_any(&self) -> &dyn Any;
@@ -62,7 +62,7 @@ pub struct Counter {
     #[cfg(feature = "metrics")]
     pub(crate) counter: prometheus_client::metrics::counter::Counter,
     /// What this counter measures.
-    description: &'static str,
+    help: &'static str,
 }
 
 impl Metric for Counter {
@@ -74,8 +74,8 @@ impl Metric for Counter {
         MetricType::Counter
     }
 
-    fn description(&self) -> &'static str {
-        self.description
+    fn help(&self) -> &'static str {
+        self.help
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -84,12 +84,12 @@ impl Metric for Counter {
 }
 
 impl Counter {
-    /// Constructs a new counter, based on the given `description`.
-    pub fn new(description: &'static str) -> Self {
+    /// Constructs a new counter, based on the given `help`.
+    pub fn new(help: &'static str) -> Self {
         Counter {
             #[cfg(feature = "metrics")]
             counter: Default::default(),
-            description,
+            help,
         }
     }
 
@@ -150,7 +150,7 @@ pub struct Gauge {
     #[cfg(feature = "metrics")]
     pub(crate) gauge: prometheus_client::metrics::gauge::Gauge,
     /// What this gauge tracks.
-    description: &'static str,
+    help: &'static str,
 }
 
 impl Metric for Gauge {
@@ -158,8 +158,8 @@ impl Metric for Gauge {
         MetricType::Gauge
     }
 
-    fn description(&self) -> &'static str {
-        self.description
+    fn help(&self) -> &'static str {
+        self.help
     }
 
     fn value(&self) -> MetricValue {
@@ -172,12 +172,12 @@ impl Metric for Gauge {
 }
 
 impl Gauge {
-    /// Constructs a new gauge, based on the given `description`.
-    pub fn new(description: &'static str) -> Self {
+    /// Constructs a new gauge, based on the given `help`.
+    pub fn new(help: &'static str) -> Self {
         Self {
             #[cfg(feature = "metrics")]
             gauge: Default::default(),
-            description,
+            help,
         }
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -40,16 +40,16 @@ impl MetricValue {
 
 /// Trait for metric items.
 pub trait Metric: std::fmt::Debug {
-    /// The type of this metric.
+    /// Returns the type of this metric.
     fn r#type(&self) -> MetricType;
 
-    /// The current value of this metric.
+    /// Returns the current value of this metric.
     fn value(&self) -> MetricValue;
 
-    /// The help string for this metric.
+    /// Returns the help string for this metric.
     fn help(&self) -> &'static str;
 
-    /// Cast this metric to [`Any`] for downcasting to concrete types.
+    /// Casts this metric to [`Any`] for downcasting to concrete types.
     fn as_any(&self) -> &dyn Any;
 }
 
@@ -93,7 +93,7 @@ impl Counter {
         }
     }
 
-    /// Increase the [`Counter`] by 1, returning the previous value.
+    /// Increases the [`Counter`] by 1, returning the previous value.
     pub fn inc(&self) -> u64 {
         #[cfg(feature = "metrics")]
         {
@@ -103,13 +103,14 @@ impl Counter {
         0
     }
 
-    /// Increase the [`Counter`] by `u64`, returning the previous value.
+    /// Increases the [`Counter`] by `u64`, returning the previous value.
     #[cfg(feature = "metrics")]
     pub fn inc_by(&self, v: u64) -> u64 {
         self.counter.inc_by(v)
     }
 
-    /// Set the [`Counter`] value.
+    /// Sets the [`Counter`] value.
+    ///
     /// Warning: this is not default behavior for a counter that should always be monotonically increasing.
     #[cfg(feature = "metrics")]
     pub fn set(&self, v: u64) -> u64 {
@@ -119,20 +120,21 @@ impl Counter {
         v
     }
 
-    /// Set the [`Counter`] value.
+    /// Sets the [`Counter`] value.
+    ///
     /// Warning: this is not default behavior for a counter that should always be monotonically increasing.
     #[cfg(not(feature = "metrics"))]
     pub fn set(&self, _v: u64) -> u64 {
         0
     }
 
-    /// Increase the [`Counter`] by `u64`, returning the previous value.
+    /// Increases the [`Counter`] by `u64`, returning the previous value.
     #[cfg(not(feature = "metrics"))]
     pub fn inc_by(&self, _v: u64) -> u64 {
         0
     }
 
-    /// Get the current value of the [`Counter`].
+    /// Returns the current value of the [`Counter`].
     pub fn get(&self) -> u64 {
         #[cfg(feature = "metrics")]
         {
@@ -181,7 +183,7 @@ impl Gauge {
         }
     }
 
-    /// Increase the [`Gauge`] by 1, returning the previous value.
+    /// Increases the [`Gauge`] by 1, returning the previous value.
     pub fn inc(&self) -> i64 {
         #[cfg(feature = "metrics")]
         {
@@ -190,18 +192,20 @@ impl Gauge {
         #[cfg(not(feature = "metrics"))]
         0
     }
-    /// Increase the [`Gauge`] by `i64`, returning the previous value.
+
+    /// Increases the [`Gauge`] by `i64`, returning the previous value.
     #[cfg(feature = "metrics")]
     pub fn inc_by(&self, v: i64) -> i64 {
         self.gauge.inc_by(v)
     }
-    /// Increase the [`Gauge`] by `i64`, returning the previous value.
+
+    /// Increases the [`Gauge`] by `i64`, returning the previous value.
     #[cfg(not(feature = "metrics"))]
     pub fn inc_by(&self, _v: u64) -> u64 {
         0
     }
 
-    /// Decrease the [`Gauge`] by 1, returning the previous value.
+    /// Decreases the [`Gauge`] by 1, returning the previous value.
     pub fn dec(&self) -> i64 {
         #[cfg(feature = "metrics")]
         {
@@ -210,18 +214,20 @@ impl Gauge {
         #[cfg(not(feature = "metrics"))]
         0
     }
-    /// Decrease the [`Gauge`] by `i64`, returning the previous value.
+
+    /// Decreases the [`Gauge`] by `i64`, returning the previous value.
     #[cfg(feature = "metrics")]
     pub fn dec_by(&self, v: i64) -> i64 {
         self.gauge.dec_by(v)
     }
-    /// Decrease the [`Gauge`] by `i64`, returning the previous value.
+
+    /// Decreases the [`Gauge`] by `i64`, returning the previous value.
     #[cfg(not(feature = "metrics"))]
     pub fn dec_by(&self, _v: u64) -> u64 {
         0
     }
 
-    /// Set the [`Gauge`] value.
+    /// Sets the [`Gauge`] value.
     #[cfg(feature = "metrics")]
     pub fn set(&self, v: i64) -> i64 {
         self.gauge
@@ -229,20 +235,22 @@ impl Gauge {
             .store(v, std::sync::atomic::Ordering::Relaxed);
         v
     }
-    /// Set the [`Gauge`] value.
+
+    /// Sets the [`Gauge`] value.
     #[cfg(not(feature = "metrics"))]
     pub fn set(&self, _v: i64) -> i64 {
         0
     }
 
-    /// Get the [`Gauge`] value.
+    /// Returns the [`Gauge`] value.
     #[cfg(feature = "metrics")]
     pub fn get(&self) -> i64 {
         self.gauge
             .inner()
             .load(std::sync::atomic::Ordering::Relaxed)
     }
-    /// Get the [`Gauge`] value.
+
+    /// Returns the [`Gauge`] value.
     #[cfg(not(feature = "metrics"))]
     pub fn get(&self) -> i64 {
         0

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,28 +1,61 @@
 use std::{
     net::SocketAddr,
-    path::PathBuf,
+    sync::{Arc, RwLock},
     time::{Duration, Instant},
 };
 
 use hyper::{service::service_fn, Request, Response};
+use prometheus_client::registry::Registry;
 use tokio::{io::AsyncWriteExt as _, net::TcpListener};
 use tracing::{debug, error, info, warn};
 
-use crate::{core::Core, parse_prometheus_metrics, Error};
+use crate::{parse_prometheus_metrics, Error};
 
 type BytesBody = http_body_util::Full<hyper::body::Bytes>;
 
-/// Start a HTTP server to report metrics.
-pub async fn run(metrics_addr: SocketAddr) -> std::io::Result<()> {
-    info!("Starting metrics server on {metrics_addr}");
-    let listener = TcpListener::bind(metrics_addr).await?;
+/// Helper trait to abstract over different ways to access metrics.
+pub trait MetricsSource: Send + 'static {
+    /// Encodes all metrics into a string in the Open Metrics text format.
+    fn encode_openmetrics(&self) -> Result<String, Error>;
+}
+
+impl MetricsSource for Registry {
+    fn encode_openmetrics(&self) -> Result<String, Error> {
+        let mut buf = String::new();
+        prometheus_client::encoding::text::encode(&mut buf, &self)
+            .expect("writing to string always works");
+        Ok(buf)
+    }
+}
+
+/// A cloneable [`Registry`] in a read-write lock.
+///
+/// Useful if you need mutable access to a registry, while also using the services
+/// defined in [`crate::service`].
+pub type RwLockRegistry = Arc<RwLock<Registry>>;
+
+impl MetricsSource for RwLockRegistry {
+    fn encode_openmetrics(&self) -> Result<String, Error> {
+        let inner = self.read().expect("poisened");
+        inner.encode_openmetrics()
+    }
+}
+
+/// Start a HTTP server to expose metrics .
+pub async fn start_metrics_server(
+    addr: SocketAddr,
+    registry: impl MetricsSource + Clone,
+) -> std::io::Result<()> {
+    info!("Starting metrics server on {addr}");
+    let listener = TcpListener::bind(addr).await?;
 
     loop {
         let (stream, _addr) = listener.accept().await?;
         let io = hyper_util::rt::TokioIo::new(stream);
+        let registry = registry.clone();
         tokio::spawn(async move {
             if let Err(err) = hyper::server::conn::http1::Builder::new()
-                .serve_connection(io, service_fn(handler))
+                .serve_connection(io, service_fn(move |req| handler(req, registry.clone())))
                 .await
             {
                 error!("Error serving metrics connection: {err:#}");
@@ -31,27 +64,13 @@ pub async fn run(metrics_addr: SocketAddr) -> std::io::Result<()> {
     }
 }
 
-/// HTTP handler that will respond with the OpenMetrics encoding of our metrics.
-async fn handler(_req: Request<hyper::body::Incoming>) -> Result<Response<BytesBody>, Error> {
-    let core = Core::get().ok_or(Error::NoMetrics)?;
-    let content = core.encode();
-    let response = Response::builder()
-        .header(hyper::header::CONTENT_TYPE, "text/plain; charset=utf-8")
-        .body(body_full(content))
-        .expect("Failed to build response");
-
-    Ok(response)
-}
-
-/// Creates a new [`BytesBody`] with given content.
-fn body_full(content: impl Into<hyper::body::Bytes>) -> BytesBody {
-    http_body_util::Full::new(content.into())
-}
-
-/// Start a metrics dumper loop to write metrics to an output file.
-pub async fn dumper(path: &PathBuf, interval_ms: Duration) -> Result<(), Error> {
-    info!(file = %path.display(), ?interval_ms, "running metrics dumper");
-    let _ = Core::get().ok_or(Error::NoMetrics)?;
+/// Start a metrics dumper service.
+pub async fn start_metrics_dumper(
+    path: std::path::PathBuf,
+    interval: std::time::Duration,
+    registry: impl MetricsSource,
+) -> Result<(), crate::Error> {
+    info!(file = %path.display(), ?interval, "running metrics dumper");
 
     let start = Instant::now();
 
@@ -65,21 +84,88 @@ pub async fn dumper(path: &PathBuf, interval_ms: Duration) -> Result<(), Error> 
     let mut file = tokio::io::BufWriter::new(file);
 
     // Dump metrics once with a header
-    dump_metrics(&mut file, &start, true).await?;
+    dump_metrics(&mut file, &start, &registry, true).await?;
     loop {
-        dump_metrics(&mut file, &start, false).await?;
-        tokio::time::sleep(interval_ms).await;
+        dump_metrics(&mut file, &start, &registry, false).await?;
+        tokio::time::sleep(interval).await;
     }
+}
+
+/// Start a metrics exporter service.
+pub async fn start_metrics_exporter(cfg: MetricsExporterConfig, registry: impl MetricsSource) {
+    let MetricsExporterConfig {
+        interval,
+        endpoint,
+        service_name,
+        instance_name,
+        username,
+        password,
+    } = cfg;
+    let push_client = reqwest::Client::new();
+    let prom_gateway_uri = format!(
+        "{}/metrics/job/{}/instance/{}",
+        endpoint, service_name, instance_name
+    );
+    loop {
+        tokio::time::sleep(interval).await;
+        let buf = match registry.encode_openmetrics() {
+            Ok(buf) => buf,
+            Err(err) => {
+                tracing::warn!("Failed to encode metrics: {err:#}");
+                break;
+            }
+        };
+        let mut req = push_client.post(&prom_gateway_uri);
+        if let Some(username) = username.clone() {
+            req = req.basic_auth(username, Some(password.clone()));
+        }
+        let res = match req.body(buf).send().await {
+            Ok(res) => res,
+            Err(e) => {
+                warn!("failed to push metrics: {}", e);
+                continue;
+            }
+        };
+        match res.status() {
+            reqwest::StatusCode::OK => {
+                debug!("pushed metrics to gateway");
+            }
+            _ => {
+                warn!("failed to push metrics to gateway: {:?}", res);
+                let body = res.text().await.unwrap();
+                warn!("error body: {}", body);
+            }
+        }
+    }
+}
+
+/// HTTP handler that will respond with the OpenMetrics encoding of our metrics.
+async fn handler(
+    _req: Request<hyper::body::Incoming>,
+    registry: impl MetricsSource,
+) -> Result<Response<BytesBody>, Error> {
+    let content = registry.encode_openmetrics()?;
+    let response = Response::builder()
+        .header(hyper::header::CONTENT_TYPE, "text/plain; charset=utf-8")
+        .body(body_full(content))
+        .expect("Failed to build response");
+
+    Ok(response)
+}
+
+/// Creates a new [`BytesBody`] with given content.
+fn body_full(content: impl Into<hyper::body::Bytes>) -> BytesBody {
+    http_body_util::Full::new(content.into())
 }
 
 /// Dump metrics to a file.
 async fn dump_metrics(
     file: &mut tokio::io::BufWriter<tokio::fs::File>,
     start: &Instant,
+    registry: &impl MetricsSource,
     write_header: bool,
 ) -> Result<(), Error> {
-    let core = Core::get().ok_or(Error::NoMetrics)?;
-    let m = core.encode();
+    let m = registry.encode_openmetrics()?;
     let m = parse_prometheus_metrics(&m);
     let time_since_start = start.elapsed().as_millis() as f64;
 
@@ -111,47 +197,32 @@ async fn dump_metrics(
     Ok(())
 }
 
-/// Export metrics to a push gateway.
-pub async fn exporter(
-    gateway_endpoint: String,
-    service_name: String,
-    instance_name: String,
-    username: Option<String>,
-    password: String,
-    interval: Duration,
-) {
-    let Some(core) = Core::get() else {
-        error!("metrics disabled");
-        return;
-    };
-    let push_client = reqwest::Client::new();
-    let prom_gateway_uri = format!(
-        "{}/metrics/job/{}/instance/{}",
-        gateway_endpoint, service_name, instance_name
-    );
-    loop {
-        tokio::time::sleep(interval).await;
-        let buff = core.encode();
-        let mut req = push_client.post(&prom_gateway_uri);
-        if let Some(username) = username.clone() {
-            req = req.basic_auth(username, Some(password.clone()));
-        }
-        let res = match req.body(buff).send().await {
-            Ok(res) => res,
-            Err(e) => {
-                warn!("failed to push metrics: {}", e);
-                continue;
-            }
-        };
-        match res.status() {
-            reqwest::StatusCode::OK => {
-                debug!("pushed metrics to gateway");
-            }
-            _ => {
-                warn!("failed to push metrics to gateway: {:?}", res);
-                let body = res.text().await.unwrap();
-                warn!("error body: {}", body);
-            }
-        }
-    }
+/// Configuration for pushing metrics to a remote endpoint.
+#[derive(PartialEq, Eq, Debug, Default, serde::Deserialize, Clone)]
+pub struct MetricsExporterConfig {
+    /// The push interval.
+    pub interval: Duration,
+    /// The endpoint url for the push metrics collector.
+    pub endpoint: String,
+    /// The name of the service you're exporting metrics for.
+    ///
+    /// Generally, `metrics_exporter` is good enough for use
+    /// outside of production deployments.
+    pub service_name: String,
+    /// The name of the instance you're exporting metrics for.
+    ///
+    /// This should be device-unique. If not, this will sum up
+    /// metrics from different devices.
+    ///
+    /// E.g. `username-laptop`, `username-phone`, etc.
+    ///
+    /// Another potential scheme with good privacy would be a
+    /// keyed blake3 hash of the secret key. (This gives you
+    /// an identifier that is as unique as a `NodeID`, but
+    /// can't be correlated to `NodeID`s.)
+    pub instance_name: String,
+    /// The username for basic auth for the push metrics collector.
+    pub username: Option<String>,
+    /// The password for basic auth for the push metrics collector.
+    pub password: String,
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,3 +1,5 @@
+//! Functions to start services that deal with metrics exposed by this crate.
+
 use std::{
     net::SocketAddr,
     sync::{Arc, RwLock},

--- a/src/service.rs
+++ b/src/service.rs
@@ -2,6 +2,7 @@
 
 use std::{
     net::SocketAddr,
+    ops::Deref,
     sync::{Arc, RwLock},
     time::{Duration, Instant},
 };
@@ -38,8 +39,14 @@ pub type RwLockRegistry = Arc<RwLock<Registry>>;
 
 impl MetricsSource for RwLockRegistry {
     fn encode_openmetrics(&self) -> Result<String, Error> {
-        let inner = self.read().expect("poisened");
+        let inner = self.read().expect("poisoned");
         inner.encode_openmetrics()
+    }
+}
+
+impl MetricsSource for Arc<Registry> {
+    fn encode_openmetrics(&self) -> Result<String, Error> {
+        Arc::deref(&self).encode_openmetrics()
     }
 }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -24,7 +24,7 @@ pub trait MetricsSource: Send + 'static {
 impl MetricsSource for Registry {
     fn encode_openmetrics(&self) -> Result<String, Error> {
         let mut buf = String::new();
-        prometheus_client::encoding::text::encode(&mut buf, &self)
+        prometheus_client::encoding::text::encode(&mut buf, self)
             .expect("writing to string always works");
         Ok(buf)
     }
@@ -142,6 +142,7 @@ pub async fn start_metrics_exporter(cfg: MetricsExporterConfig, registry: impl M
 }
 
 /// HTTP handler that will respond with the OpenMetrics encoding of our metrics.
+#[allow(clippy::unused_async)]
 async fn handler(
     _req: Request<hyper::body::Incoming>,
     registry: impl MetricsSource,

--- a/src/service.rs
+++ b/src/service.rs
@@ -46,7 +46,7 @@ impl MetricsSource for RwLockRegistry {
 
 impl MetricsSource for Arc<Registry> {
     fn encode_openmetrics(&self) -> Result<String, Error> {
-        Arc::deref(&self).encode_openmetrics()
+        Arc::deref(self).encode_openmetrics()
     }
 }
 

--- a/src/static_core.rs
+++ b/src/static_core.rs
@@ -10,7 +10,7 @@
 //!
 //! # Example:
 //! ```rust
-//! use iroh_metrics::{inc, inc_by, static_core::Core, Iterable, Counter, MetricsGroup};
+//! use iroh_metrics::{inc, inc_by, static_core::Core, Counter, Iterable, MetricsGroup};
 //!
 //! #[derive(Debug, Clone, Iterable)]
 //! pub struct Metrics {

--- a/src/static_core.rs
+++ b/src/static_core.rs
@@ -10,8 +10,7 @@
 //!
 //! # Example:
 //! ```rust
-//! use iroh_metrics::{inc, inc_by, static_core::Core, Counter, MetricsGroup};
-//! use struct_iterable::Iterable;
+//! use iroh_metrics::{inc, inc_by, static_core::Core, Iterable, Counter, MetricsGroup};
 //!
 //! #[derive(Debug, Clone, Iterable)]
 //! pub struct Metrics {

--- a/src/static_core.rs
+++ b/src/static_core.rs
@@ -130,7 +130,7 @@ impl Core {
     }
 }
 
-/// Increments the given counter or gauge by 1.
+/// Increments the given metric by 1.
 #[macro_export]
 macro_rules! inc {
     ($m:ty, $f:ident) => {
@@ -140,7 +140,7 @@ macro_rules! inc {
     };
 }
 
-/// Increments the given counter or gauge by `n`.
+/// Increments the given metric by `n`.
 #[macro_export]
 macro_rules! inc_by {
     ($m:ty, $f:ident, $n:expr) => {
@@ -150,7 +150,7 @@ macro_rules! inc_by {
     };
 }
 
-/// Sets the given counter or gauge to `n`.
+/// Sets the given metric to `n`.
 #[macro_export]
 macro_rules! set {
     ($m:ty, $f:ident, $n:expr) => {
@@ -158,7 +158,7 @@ macro_rules! set {
     };
 }
 
-/// Decrements the given gauge by 1.
+/// Decrements the given metric by 1.
 #[macro_export]
 macro_rules! dec {
     ($m:ty, $f:ident) => {
@@ -168,7 +168,7 @@ macro_rules! dec {
     };
 }
 
-/// Decrements the given gauge `n`.
+/// Decrements the given metric by `n`.
 #[macro_export]
 macro_rules! dec_by {
     ($m:ty, $f:ident, $n:expr) => {

--- a/src/static_core.rs
+++ b/src/static_core.rs
@@ -10,11 +10,7 @@
 //!
 //! # Example:
 //! ```rust
-//! use iroh_metrics::{
-//!     static_core::Core,
-//!     Counter, Metric,
-//!     inc, inc_by,
-//! };
+//! use iroh_metrics::{inc, inc_by, static_core::Core, Counter, Metric};
 //! use struct_iterable::Iterable;
 //!
 //! #[derive(Debug, Clone, Iterable)]

--- a/src/static_core.rs
+++ b/src/static_core.rs
@@ -53,7 +53,7 @@ use erased_set::ErasedSyncSet;
 #[cfg(feature = "metrics")]
 use prometheus_client::{encoding::text::encode, registry::Registry};
 
-use crate::{base::Metric, Error};
+use crate::base::Metric;
 
 #[cfg(not(feature = "metrics"))]
 type Registry = ();
@@ -66,8 +66,8 @@ pub struct GlobalRegistry;
 
 #[cfg(feature = "service")]
 impl crate::service::MetricsSource for GlobalRegistry {
-    fn encode_openmetrics(&self) -> Result<String, Error> {
-        let core = crate::static_core::Core::get().ok_or(Error::NoMetrics)?;
+    fn encode_openmetrics(&self) -> Result<String, crate::Error> {
+        let core = crate::static_core::Core::get().ok_or(crate::Error::NoMetrics)?;
         Ok(core.encode())
     }
 }

--- a/src/static_core.rs
+++ b/src/static_core.rs
@@ -10,7 +10,7 @@
 //!
 //! # Example:
 //! ```rust
-//! use iroh_metrics::{inc, inc_by, static_core::Core, Counter, Iterable, MetricsGroup};
+//! use iroh_metrics::{inc, inc_by, iterable::Iterable, static_core::Core, Counter, MetricsGroup};
 //!
 //! #[derive(Debug, Clone, Iterable)]
 //! pub struct Metrics {

--- a/src/static_core.rs
+++ b/src/static_core.rs
@@ -10,7 +10,7 @@
 //!
 //! # Example:
 //! ```rust
-//! use iroh_metrics::{inc, inc_by, static_core::Core, Counter, Metric};
+//! use iroh_metrics::{inc, inc_by, static_core::Core, Counter, MetricsGroup};
 //! use struct_iterable::Iterable;
 //!
 //! #[derive(Debug, Clone, Iterable)]
@@ -28,7 +28,7 @@
 //!     }
 //! }
 //!
-//! impl Metric for Metrics {
+//! impl MetricsGroup for Metrics {
 //!     fn name(&self) -> &'static str {
 //!         "my_metrics"
 //!     }
@@ -50,7 +50,7 @@ use erased_set::ErasedSyncSet;
 #[cfg(feature = "metrics")]
 use prometheus_client::{encoding::text::encode, registry::Registry};
 
-use crate::base::Metric;
+use crate::base::MetricsGroup;
 
 #[cfg(not(feature = "metrics"))]
 type Registry = ();
@@ -117,7 +117,7 @@ impl Core {
     }
 
     /// Returns a reference to the mapped metrics instance.
-    pub fn get_collector<T: Metric>(&self) -> Option<&T> {
+    pub fn get_collector<T: MetricsGroup>(&self) -> Option<&T> {
         self.metrics_map.get::<T>()
     }
 

--- a/src/static_core.rs
+++ b/src/static_core.rs
@@ -1,0 +1,183 @@
+//! Metrics collection in a static, process-level global metrics collector.
+//!
+//! Enables and manages a global registry of metrics.
+//! Divided up into modules, each module has its own metrics.
+//!
+//! - To increment a **counter**, use the [`crate::inc`] macro with a value.
+//! - To increment a **counter** by 1, use the [`crate::inc_by`] macro.
+//!
+//! To expose the metrics, start the metrics service with `start_metrics_server()`.
+//!
+//! # Example:
+//! ```rust
+//! use iroh_metrics::{
+//!     core::{Core, Counter, Metric},
+//!     inc, inc_by,
+//! };
+//! use struct_iterable::Iterable;
+//!
+//! #[derive(Debug, Clone, Iterable)]
+//! pub struct Metrics {
+//!     pub things_added: Counter,
+//! }
+//!
+//! impl Default for Metrics {
+//!     fn default() -> Self {
+//!         Self {
+//!             things_added: Counter::new(
+//!                 "things_added tracks the number of things we have added",
+//!             ),
+//!         }
+//!     }
+//! }
+//!
+//! impl Metric for Metrics {
+//!     fn name(&self) -> &'static str {
+//!         "my_metrics"
+//!     }
+//! }
+//!
+//! Core::init(|reg, metrics| {
+//!     let m = Metrics::default();
+//!     m.register(reg);
+//!     metrics.insert(m);
+//! });
+//!
+//! inc_by!(Metrics, things_added, 2);
+//! inc!(Metrics, things_added);
+//! ```
+
+use std::sync::OnceLock;
+
+use erased_set::ErasedSyncSet;
+#[cfg(feature = "metrics")]
+use prometheus_client::{encoding::text::encode, registry::Registry};
+
+use crate::{base::Metric, Error};
+
+#[cfg(not(feature = "metrics"))]
+type Registry = ();
+
+/// This struct can be used with the functions in [`crate::service`] to use them with
+/// the global static [`Core`] defined in this module.
+#[cfg(feature = "service")]
+#[derive(Clone, Copy, Debug)]
+pub struct GlobalRegistry;
+
+#[cfg(feature = "service")]
+impl crate::service::MetricsSource for GlobalRegistry {
+    fn encode_openmetrics(&self) -> Result<String, Error> {
+        let core = crate::static_core::Core::get().ok_or(Error::NoMetrics)?;
+        Ok(core.encode())
+    }
+}
+
+static CORE: OnceLock<Core> = OnceLock::new();
+
+/// Core is the base metrics struct.
+///
+/// It manages the mapping between the metrics name and the actual metrics.
+/// It also carries a single prometheus registry to be used by all metrics.
+#[derive(Debug, Default)]
+pub struct Core {
+    #[cfg(feature = "metrics")]
+    registry: Registry,
+    metrics_map: ErasedSyncSet,
+}
+
+impl Core {
+    /// Must only be called once to init metrics.
+    ///
+    /// Panics if called a second time.
+    pub fn init<F: FnOnce(&mut Registry, &mut ErasedSyncSet)>(f: F) {
+        Self::try_init(f).expect("must only be called once");
+    }
+
+    /// Trieds to init the metrics.
+    #[cfg_attr(not(feature = "metrics"), allow(clippy::let_unit_value))]
+    pub fn try_init<F: FnOnce(&mut Registry, &mut ErasedSyncSet)>(f: F) -> std::io::Result<()> {
+        let mut registry = Registry::default();
+        let mut metrics_map = ErasedSyncSet::new();
+        f(&mut registry, &mut metrics_map);
+
+        CORE.set(Core {
+            metrics_map,
+            #[cfg(feature = "metrics")]
+            registry,
+        })
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::Other, "already set"))
+    }
+
+    /// Returns a reference to the core metrics.
+    pub fn get() -> Option<&'static Self> {
+        CORE.get()
+    }
+
+    /// Returns a reference to the prometheus registry.
+    #[cfg(feature = "metrics")]
+    pub fn registry(&self) -> &Registry {
+        &self.registry
+    }
+
+    /// Returns a reference to the mapped metrics instance.
+    pub fn get_collector<T: Metric>(&self) -> Option<&T> {
+        self.metrics_map.get::<T>()
+    }
+
+    /// Encodes the current metrics registry to a string in
+    /// the prometheus text exposition format.
+    #[cfg(feature = "metrics")]
+    pub fn encode(&self) -> String {
+        let mut buf = String::new();
+        encode(&mut buf, &self.registry).expect("writing to string always works");
+        buf
+    }
+}
+
+/// Increments the given counter or gauge by 1.
+#[macro_export]
+macro_rules! inc {
+    ($m:ty, $f:ident) => {
+        if let Some(m) = $crate::static_core::Core::get().and_then(|c| c.get_collector::<$m>()) {
+            m.$f.inc();
+        }
+    };
+}
+
+/// Increments the given counter or gauge by `n`.
+#[macro_export]
+macro_rules! inc_by {
+    ($m:ty, $f:ident, $n:expr) => {
+        if let Some(m) = $crate::static_core::Core::get().and_then(|c| c.get_collector::<$m>()) {
+            m.$f.inc_by($n);
+        }
+    };
+}
+
+/// Sets the given counter or gauge to `n`.
+#[macro_export]
+macro_rules! set {
+    ($m:ty, $f:ident, $n:expr) => {
+        <$m as $crate::static_core::Metric>::with_metric(|m| m.$f.set($n));
+    };
+}
+
+/// Decrements the given gauge by 1.
+#[macro_export]
+macro_rules! dec {
+    ($m:ty, $f:ident) => {
+        if let Some(m) = $crate::static_core::Core::get().and_then(|c| c.get_collector::<$m>()) {
+            m.$f.dec();
+        }
+    };
+}
+
+/// Decrements the given gauge `n`.
+#[macro_export]
+macro_rules! dec_by {
+    ($m:ty, $f:ident, $n:expr) => {
+        if let Some(m) = $crate::static_core::Core::get().and_then(|c| c.get_collector::<$m>()) {
+            m.$f.dec_by($n);
+        }
+    };
+}

--- a/src/static_core.rs
+++ b/src/static_core.rs
@@ -11,7 +11,8 @@
 //! # Example:
 //! ```rust
 //! use iroh_metrics::{
-//!     core::{Core, Counter, Metric},
+//!     static_core::Core,
+//!     Counter, Metric,
 //!     inc, inc_by,
 //! };
 //! use struct_iterable::Iterable;


### PR DESCRIPTION
## Description

* Makes the static superglobal `Core` optional behind the new `static_core` feature. The macros to modify metrics tracked in the static core, `inc`, `inc_by`, etc are also behind this feature flag now.
* Makes the `Metric` trait dyn-compatible, and renames it to `MetricsGroup`. The `name` method now takes `&self`. Adds a `register(&self, registry: &mut Registry)` method to the `Metric` trait to register already-constructed metrics to a prometheus-client registry. The `new` method is moved to a new trait `MetricsGroupExt` which is auto-impl'd for all types that impl `MetricsGroup`. 
* Adds a new `Metric` trait that is implemented on `Gauge` and `Counter` to provide a common interface.
* Adds a custom trait and derive macro `Iterable` that works similar to `struct_iterable`, but returns an iterator over `&dyn Metric` and does not allocate for iteration. Removes the `struct_iterable` dependency.
* Adds a derive macro `MetricsGroup` that expands to the `Iterable` impl and also implements `Default` by calling `FieldType::new(description)` for each field, where `description` is the first line of the field's doc comment, or a custom string set via `#[metrics(description = "my description")]`. Also implements `MetricsGroup`, with a `name` of either the struct name converted to camel_case, or a custom name set via `#[metrics_group(name = "my_name")]`
* Adds a trait `MetricsGroupSet` that can be implemented on structs that contain multiple structs which each implement `Metric`. Requires a method `groups(&self) -> impl Iterator<Item = &dyn MetricsGroup>` to iterate over all contained metric structs. Provides a method `register(&self, registry: &mut Registry)` which uses `iter` to register all contained metrics onto a prometheus-client registry. Provides a method `iter(&self) -> impl Iterator<Item = (&'static str, &dyn MetricItem>` to iterate over all metric items from all contained groups.
* Modifies the functions to start services (`start_metrics_service`, `start_metrics_dumper`, `start_metrics_exporter`) to take a `impl MetricsSource` as additional required argument. When the `static_core` feature is enabled, you can pass the zerosized `GlobalRegistry` struct, which impls MetricsSource and exposes all metrics contained in the static `Core`. When not using the static core, you can either pass a `Registry` or an `Arc<RwLock<Registry>>` to run the services for a regular registry created in application code.


## Breaking Changes

Most import paths changed, but apart from that it is mostly API additions. Migration should be straightforward.

* `iroh_metrics::core::{Counter, Gauge}` are now `iroh_metrics::{Counter, Gauge}`
* `iroh_metrics::core::Metric` is now `iroh_metrics::MetricsGroup`.
  * `MetricsGroup::name` now takes `&self` as argument
  * `MetricsGroup::new` is removed.
* `metrics::{start_metrics_server, start_metrics_exporter, start_metrics_dumper}` is now  `service::{start_metrics_server, start_metrics_exporter, start_metrics_dumper}`. They all take a `registry` argument, which takes any `T: impl MetricSource`. For the old behavior of using the static `Core`, pass the zero-sized struct `static_core::GlobalRegistry`.
* `iroh_metrics::core::Core` is now at `iroh_metrics::static_core::Core` and behind the `static_core` feature flag (not enabled by default)
* The macros `inc`, `inc_by`, `set`, `dec`, `dec_by` are now behind the `static_core` feature flag (not enabled by default)
* `iroh_metrics::core` module is removed
* `struct_iterable::Iterable` is no longer exported from `iroh-metrics`, and is no longer a supertrait of `MetricsGroup`
  * instead, `MetricsGroup` now has `iroh_metrics::Iterable` and `iroh_metrics::IntoIterable` supertraits. They can be implemented manually, but it is recommended to use the new `MetricsGroup` or `Iterable` derive macros exported from `iroh_metrics`. See their docs for details.
  * There is now a `iroh_metrics::MetricsGroup` derive macro that includes the functionality previously provided by `struct_iterable`. 

## Notes & open questions
<!-- Any notes, remarks or open questions you have to make about the PR. -->
## Change checklist
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.