### PR TITLE
feat: derive macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "http"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +450,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "iroh-metrics-derive",
  "prometheus-client",
  "reqwest",
  "serde",
@@ -451,6 +458,17 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "iroh-metrics-derive"
+version = "0.1.0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "struct_iterable_derive",
+ "syn",
 ]
 
 [[package]]
@@ -596,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -680,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,15 +107,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
 
 [[package]]
-name = "erased-serde"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "erased_set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,7 +445,6 @@ dependencies = [
  "prometheus-client",
  "reqwest",
  "serde",
- "struct_iterable",
  "thiserror",
  "tokio",
  "tracing",
@@ -467,7 +457,6 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "struct_iterable_derive",
  "syn",
 ]
 
@@ -947,35 +936,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "struct_iterable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "849a064c6470a650b72e41fa6c057879b68f804d113af92900f27574828e7712"
-dependencies = [
- "struct_iterable_derive",
- "struct_iterable_internal",
-]
-
-[[package]]
-name = "struct_iterable_derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb939ce88a43ea4e9d012f2f6b4cc789deb2db9d47bad697952a85d6978662c"
-dependencies = [
- "erased-serde",
- "proc-macro2",
- "quote",
- "struct_iterable_internal",
- "syn",
-]
-
-[[package]]
-name = "struct_iterable_internal"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9426b2a0c03e6cc2ea8dbc0168dbbf943f88755e409fb91bcb8f6a268305f4a"
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = ["iroh-metrics-derive"]
+
 [package]
 name = "iroh-metrics"
 version = "0.32.0"
@@ -45,6 +48,9 @@ hyper-util = { version = "0.1.1", features = ["tokio"], optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
 tokio = { version = "1", features = ["rt", "net", "fs"], optional = true }
 
+# derive feature
+iroh-metrics-derive = { path = "./iroh-metrics-derive", optional = true }
+
 [dev-dependencies]
 tokio = { version = "1", features = ["io-util", "sync", "rt", "net", "fs", "macros", "time", "test-util"] }
 
@@ -68,6 +74,8 @@ service = [
 ]
 # Enables a global, static metrics collector
 static_core = ["metrics", "dep:erased_set"]
+# Enables the MetricsGroup derive macro
+derive = ["dep:iroh-metrics-derive"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ unused-async = "warn"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
-struct_iterable = "0.1"
 thiserror = "2.0.6"
 tracing = "0.1"
 
@@ -49,7 +48,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 tokio = { version = "1", features = ["rt", "net", "fs"], optional = true }
 
 # derive feature
-iroh-metrics-derive = { path = "./iroh-metrics-derive", optional = true }
+iroh-metrics-derive = { path = "./iroh-metrics-derive" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["io-util", "sync", "rt", "net", "fs", "macros", "time", "test-util"] }
@@ -74,8 +73,6 @@ service = [
 ]
 # Enables a global, static metrics collector
 static_core = ["metrics", "dep:erased_set"]
-# Enables the MetricsGroup derive macro
-derive = ["dep:iroh-metrics-derive"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/iroh-metrics-derive/Cargo.toml
+++ b/iroh-metrics-derive/Cargo.toml
@@ -10,5 +10,4 @@ proc-macro = true
 heck = "0.5.0"
 proc-macro2 = "1.0.94"
 quote = "1.0.40"
-struct_iterable_derive = "0.1.0"
 syn = "2"

--- a/iroh-metrics-derive/Cargo.toml
+++ b/iroh-metrics-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iroh-metrics-derive"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/iroh-metrics-derive/Cargo.toml
+++ b/iroh-metrics-derive/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "iroh-metrics-derive"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+heck = "0.5.0"
+proc-macro2 = "1.0.94"
+quote = "1.0.40"
+struct_iterable_derive = "0.1.0"
+syn = "2"

--- a/iroh-metrics-derive/src/lib.rs
+++ b/iroh-metrics-derive/src/lib.rs
@@ -1,0 +1,105 @@
+use heck::ToSnakeCase;
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{
+    Attribute, DeriveInput, Expr, ExprLit, Fields, Lit, Meta, MetaList, MetaNameValue,
+    parse::Parser, parse_macro_input,
+};
+
+#[proc_macro_derive(MetricsGroup, attributes(metrics))]
+pub fn derive_metrics_group(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    impl_metrics(&input).into()
+}
+
+fn impl_metrics(input: &DeriveInput) -> proc_macro2::TokenStream {
+    let name = &input.ident;
+
+    let syn::Data::Struct(data) = &input.data else {
+        panic!("Only structs are supported.")
+    };
+    let Fields::Named(_fields) = &data.fields else {
+        panic!("Only structs with named fields are supported.")
+    };
+
+    let mut fields_impl = quote! {};
+
+    for field in &data.fields {
+        let field_name = field.ident.as_ref().unwrap();
+        let ty = &field.ty;
+        let doc = parse_doc_comment(&field.attrs)
+            .first()
+            .cloned()
+            .unwrap_or_else(|| field_name.to_string());
+        fields_impl = quote! {
+            #fields_impl
+            #field_name: #ty::new(#doc),
+        };
+    }
+
+    let attr_name =
+        parse_metrics_name(&input.attrs).unwrap_or_else(|| name.to_string().to_snake_case());
+
+    quote! {
+        impl Default for #name {
+            fn default() -> Self {
+                Self {
+                    #fields_impl
+                }
+            }
+        }
+
+        impl MetricsGroup for #name {
+            fn name(&self) -> &'static str {
+                #attr_name
+            }
+        }
+    }
+}
+
+fn parse_doc_comment(attrs: &[Attribute]) -> Vec<String> {
+    let mut lines = vec![];
+    for attr in attrs {
+        if let Meta::NameValue(MetaNameValue { path, value, .. }) = &attr.meta {
+            if path.is_ident("doc") {
+                if let Expr::Lit(ExprLit {
+                    lit: Lit::Str(lit_str),
+                    ..
+                }) = value
+                {
+                    lines.push(lit_str.value().trim().to_string());
+                }
+            }
+        }
+    }
+    lines
+}
+
+fn parse_metrics_name(attrs: &[Attribute]) -> Option<String> {
+    for attr in attrs {
+        if let Meta::List(MetaList { path, tokens, .. }) = &attr.meta {
+            if path.is_ident("metrics") {
+                let parser = syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated;
+                if let Ok(parsed) = parser.parse2(tokens.clone()) {
+                    for meta in parsed {
+                        if let Meta::NameValue(MetaNameValue {
+                            path,
+                            value:
+                                Expr::Lit(ExprLit {
+                                    lit: Lit::Str(lit_str),
+                                    ..
+                                }),
+                            ..
+                        }) = meta
+                        {
+                            if path.is_ident("name") {
+                                return Some(lit_str.value());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}

--- a/iroh-metrics-derive/src/lib.rs
+++ b/iroh-metrics-derive/src/lib.rs
@@ -78,7 +78,7 @@ fn impl_metrics(input: &DeriveInput) -> proc_macro2::TokenStream {
         let field_name = field.ident.as_ref().unwrap();
         let ty = &field.ty;
         let doc = parse_doc_comment(&field.attrs)
-            .get(0)
+            .first()
             .cloned()
             .unwrap_or_else(|| field_name.to_string());
         fields_impl = quote! {
@@ -107,7 +107,7 @@ fn impl_metrics(input: &DeriveInput) -> proc_macro2::TokenStream {
     }
 }
 
-fn parse_doc_comment<'a>(attrs: &'a [Attribute]) -> Vec<String> {
+fn parse_doc_comment(attrs: &[Attribute]) -> Vec<String> {
     let mut lines = vec![];
     for attr in attrs {
         if let Meta::NameValue(MetaNameValue { path, value, .. }) = &attr.meta {

--- a/src/base.rs
+++ b/src/base.rs
@@ -1,3 +1,5 @@
+use std::any::Any;
+
 #[cfg(feature = "metrics")]
 pub use prometheus_client::registry::Registry;
 
@@ -5,8 +7,6 @@ use crate::{
     metrics::{Counter, Gauge},
     FieldIter, IntoIterable, Iterable, MetricType,
 };
-
-use std::any::Any;
 /// Description of a group of metrics.
 pub trait MetricsGroup:
     Any + Iterable + IntoIterable + std::fmt::Debug + 'static + Send + Sync
@@ -206,9 +206,8 @@ mod tests {
 /// Tests with the `metrics` feature,
 #[cfg(all(test, feature = "metrics"))]
 mod tests {
-    use crate::Iterable;
-
     use super::*;
+    use crate::Iterable;
 
     #[derive(Debug, Clone, Iterable)]
     pub struct FooMetrics {

--- a/src/iterable.rs
+++ b/src/iterable.rs
@@ -1,0 +1,74 @@
+use std::fmt;
+
+/// Trait for iterating over the fields of a struct.
+pub trait Iterable {
+    /// Returns the number of fields in the struct.
+    fn field_count(&self) -> usize;
+    /// Returns the field name and dyn reference to the field.
+    fn field(&self, n: usize) -> Option<(&'static str, &dyn std::any::Any)>;
+}
+
+impl dyn Iterable {
+    /// Returns an iterator over the fields of the struct.
+    pub fn iter(&self) -> FieldIter<'_> {
+        FieldIter::new(self)
+    }
+}
+
+/// Helper trait to convert from `self` to `dyn Iterable`.
+pub trait IntoIterable {
+    /// Returns `self` as `dyn Iterable`
+    fn as_iterable(&self) -> &dyn Iterable;
+
+    /// Returns an iterator over the fields of the struct.
+    fn iter(&self) -> FieldIter<'_> {
+        FieldIter::new(self.as_iterable())
+    }
+}
+
+impl<T> IntoIterable for T
+where
+    T: Iterable,
+{
+    fn as_iterable(&self) -> &dyn Iterable {
+        self
+    }
+}
+
+/// Iterator over the fields of a struct.
+///
+/// Returned from [`Iterable::iter`] and [`dyn Iterable::dyn_iter`].
+pub struct FieldIter<'a> {
+    pos: usize,
+    inner: &'a dyn Iterable,
+}
+
+impl<'a> fmt::Debug for FieldIter<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "FieldIter")
+    }
+}
+
+impl<'a> FieldIter<'a> {
+    pub(crate) fn new(inner: &'a dyn Iterable) -> Self {
+        Self { pos: 0, inner }
+    }
+}
+impl<'a> Iterator for FieldIter<'a> {
+    type Item = (&'static str, &'a dyn std::any::Any);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.pos == self.inner.field_count() {
+            None
+        } else {
+            let out = self.inner.field(self.pos);
+            self.pos += 1;
+            out
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let n = self.inner.field_count() - self.pos;
+        (n, Some(n))
+    }
+}

--- a/src/iterable.rs
+++ b/src/iterable.rs
@@ -37,13 +37,13 @@ where
 
 /// Iterator over the fields of a struct.
 ///
-/// Returned from [`Iterable::iter`] and [`dyn Iterable::dyn_iter`].
+/// Returned from [`IntoIterable::iter`].
 pub struct FieldIter<'a> {
     pos: usize,
     inner: &'a dyn Iterable,
 }
 
-impl<'a> fmt::Debug for FieldIter<'a> {
+impl fmt::Debug for FieldIter<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "FieldIter")
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@
 /// Exposes core types and traits
 mod base;
 pub use base::*;
+#[cfg(feature = "derive")]
+pub use iroh_metrics_derive::MetricsGroup;
 
 mod metrics;
 pub use metrics::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,14 +2,17 @@
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![cfg_attr(iroh_docsrs, feature(doc_auto_cfg))]
 
+pub use iroh_metrics_derive::{Iterable, MetricsGroup};
+
 /// Exposes core types and traits
 mod base;
 pub use base::*;
-#[cfg(feature = "derive")]
-pub use iroh_metrics_derive::MetricsGroup;
 
 mod metrics;
 pub use metrics::*;
+
+mod iterable;
+pub use iterable::*;
 
 #[cfg(feature = "static_core")]
 pub mod static_core;
@@ -18,9 +21,6 @@ pub mod static_core;
 pub mod service;
 
 use std::collections::HashMap;
-
-/// Reexports `struct_iterable` to make matching versions easier.
-pub use struct_iterable;
 
 /// Potential errors from this library.
 #[derive(Debug, thiserror::Error)]

--- a/src/static_core.rs
+++ b/src/static_core.rs
@@ -10,7 +10,7 @@
 //!
 //! # Example:
 //! ```rust
-//! use iroh_metrics::{inc, inc_by, static_core::Core, Iterable, Counter, MetricsGroup};
+//! use iroh_metrics::{inc, inc_by, static_core::Core, Counter, Iterable, MetricsGroup};
 //!
 //! #[derive(Debug, Clone, Iterable)]
 //! pub struct Metrics {

--- a/src/static_core.rs
+++ b/src/static_core.rs
@@ -10,8 +10,7 @@
 //!
 //! # Example:
 //! ```rust
-//! use iroh_metrics::{inc, inc_by, static_core::Core, Counter, MetricsGroup};
-//! use struct_iterable::Iterable;
+//! use iroh_metrics::{inc, inc_by, static_core::Core, Iterable, Counter, MetricsGroup};
 //!
 //! #[derive(Debug, Clone, Iterable)]
 //! pub struct Metrics {


### PR DESCRIPTION
## Description

Adds a derive macro that does the `Default` impl by using the first line of the docstring of each field as the prometheus description. Saves effort, and we have the description as docstring as well (currently most metrics in iroh don't have a docstring).

Removes the `struct_iterable` dependeny, and instead add a `Iterable` trait and derive macro to the crate itself. Saves the vector allocation per iteration that struct_iterable uses, and if derive `MetricsGroup` no further derives are needed.

## Breaking Changes
<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->
## Notes & open questions
<!-- Any notes, remarks or open questions you have to make about the PR. -->
## Change checklist
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.