### PR TITLE
refactor: Add derive macro and `Metric` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "http"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +450,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "iroh-metrics-derive",
  "prometheus-client",
  "reqwest",
  "serde",
@@ -451,6 +458,17 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "iroh-metrics-derive"
+version = "0.1.0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "struct_iterable_derive",
+ "syn",
 ]
 
 [[package]]
@@ -596,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -680,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,15 +107,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
 
 [[package]]
-name = "erased-serde"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "erased_set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,7 +445,6 @@ dependencies = [
  "prometheus-client",
  "reqwest",
  "serde",
- "struct_iterable",
  "thiserror",
  "tokio",
  "tracing",
@@ -467,7 +457,6 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "struct_iterable_derive",
  "syn",
 ]
 
@@ -947,35 +936,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "struct_iterable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "849a064c6470a650b72e41fa6c057879b68f804d113af92900f27574828e7712"
-dependencies = [
- "struct_iterable_derive",
- "struct_iterable_internal",
-]
-
-[[package]]
-name = "struct_iterable_derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb939ce88a43ea4e9d012f2f6b4cc789deb2db9d47bad697952a85d6978662c"
-dependencies = [
- "erased-serde",
- "proc-macro2",
- "quote",
- "struct_iterable_internal",
- "syn",
-]
-
-[[package]]
-name = "struct_iterable_internal"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9426b2a0c03e6cc2ea8dbc0168dbbf943f88755e409fb91bcb8f6a268305f4a"
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = ["iroh-metrics-derive"]
+
 [package]
 name = "iroh-metrics"
 version = "0.32.0"
@@ -45,6 +48,9 @@ hyper-util = { version = "0.1.1", features = ["tokio"], optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
 tokio = { version = "1", features = ["rt", "net", "fs"], optional = true }
 
+# derive feature
+iroh-metrics-derive = { path = "./iroh-metrics-derive", optional = true }
+
 [dev-dependencies]
 tokio = { version = "1", features = ["io-util", "sync", "rt", "net", "fs", "macros", "time", "test-util"] }
 
@@ -68,6 +74,8 @@ service = [
 ]
 # Enables a global, static metrics collector
 static_core = ["metrics", "dep:erased_set"]
+# Enables the MetricsGroup derive macro
+derive = ["dep:iroh-metrics-derive"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ unused-async = "warn"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
-struct_iterable = "0.1"
 thiserror = "2.0.6"
 tracing = "0.1"
 
@@ -49,7 +48,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 tokio = { version = "1", features = ["rt", "net", "fs"], optional = true }
 
 # derive feature
-iroh-metrics-derive = { path = "./iroh-metrics-derive", optional = true }
+iroh-metrics-derive = { path = "./iroh-metrics-derive" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["io-util", "sync", "rt", "net", "fs", "macros", "time", "test-util"] }
@@ -74,8 +73,6 @@ service = [
 ]
 # Enables a global, static metrics collector
 static_core = ["metrics", "dep:erased_set"]
-# Enables the MetricsGroup derive macro
-derive = ["dep:iroh-metrics-derive"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/iroh-metrics-derive/Cargo.toml
+++ b/iroh-metrics-derive/Cargo.toml
@@ -10,5 +10,4 @@ proc-macro = true
 heck = "0.5.0"
 proc-macro2 = "1.0.94"
 quote = "1.0.40"
-struct_iterable_derive = "0.1.0"
 syn = "2"

--- a/iroh-metrics-derive/Cargo.toml
+++ b/iroh-metrics-derive/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
-heck = "0.5.0"
-proc-macro2 = "1.0.94"
-quote = "1.0.40"
+heck = "0.5"
+proc-macro2 = "1"
+quote = "1"
 syn = "2"

--- a/iroh-metrics-derive/Cargo.toml
+++ b/iroh-metrics-derive/Cargo.toml
@@ -2,6 +2,10 @@
 name = "iroh-metrics-derive"
 version = "0.1.0"
 edition = "2021"
+description = "derive macros for iroh-metrics"
+license = "MIT OR Apache-2.0"
+authors = ["Frando <franz@n0.computer>", "n0 team"]
+repository = "https://github.com/n0-computer/iroh-metrics"
 
 [lib]
 proc-macro = true

--- a/iroh-metrics-derive/Cargo.toml
+++ b/iroh-metrics-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iroh-metrics-derive"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/iroh-metrics-derive/Cargo.toml
+++ b/iroh-metrics-derive/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "iroh-metrics-derive"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+heck = "0.5.0"
+proc-macro2 = "1.0.94"
+quote = "1.0.40"
+struct_iterable_derive = "0.1.0"
+syn = "2"

--- a/iroh-metrics-derive/src/lib.rs
+++ b/iroh-metrics-derive/src/lib.rs
@@ -32,7 +32,7 @@ fn expand_iterable(input: &DeriveInput) -> Result<proc_macro2::TokenStream, Erro
         let ident = field.ident.as_ref().unwrap();
         let ident_str = ident.to_string();
         match_arms.extend(quote! {
-            #i => Some((#ident_str, &self.#ident as &dyn ::std::any::Any)),
+            #i => Some((#ident_str, &self.#ident as &dyn ::iroh_metrics::Metric)),
         });
     }
 
@@ -42,7 +42,7 @@ fn expand_iterable(input: &DeriveInput) -> Result<proc_macro2::TokenStream, Erro
                 #count
             }
 
-            fn field(&self, n: usize) -> Option<(&'static str, &dyn ::std::any::Any)> {
+            fn field_ref(&self, n: usize) -> Option<(&'static str, &dyn ::iroh_metrics::Metric)> {
                 match n {
                     #match_arms
                     _ => None,

--- a/iroh-metrics-derive/src/lib.rs
+++ b/iroh-metrics-derive/src/lib.rs
@@ -1,0 +1,105 @@
+use heck::ToSnakeCase;
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{
+    Attribute, DeriveInput, Expr, ExprLit, Fields, Lit, Meta, MetaList, MetaNameValue,
+    parse::Parser, parse_macro_input,
+};
+
+#[proc_macro_derive(MetricsGroup, attributes(metrics))]
+pub fn derive_metrics_group(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    impl_metrics(&input).into()
+}
+
+fn impl_metrics(input: &DeriveInput) -> proc_macro2::TokenStream {
+    let name = &input.ident;
+
+    let syn::Data::Struct(data) = &input.data else {
+        panic!("Only structs are supported.")
+    };
+    let Fields::Named(_fields) = &data.fields else {
+        panic!("Only structs with named fields are supported.")
+    };
+
+    let mut fields_impl = quote! {};
+
+    for field in &data.fields {
+        let field_name = field.ident.as_ref().unwrap();
+        let ty = &field.ty;
+        let doc = parse_doc_comment(&field.attrs)
+            .first()
+            .cloned()
+            .unwrap_or_else(|| field_name.to_string());
+        fields_impl = quote! {
+            #fields_impl
+            #field_name: #ty::new(#doc),
+        };
+    }
+
+    let attr_name =
+        parse_metrics_name(&input.attrs).unwrap_or_else(|| name.to_string().to_snake_case());
+
+    quote! {
+        impl Default for #name {
+            fn default() -> Self {
+                Self {
+                    #fields_impl
+                }
+            }
+        }
+
+        impl MetricsGroup for #name {
+            fn name(&self) -> &'static str {
+                #attr_name
+            }
+        }
+    }
+}
+
+fn parse_doc_comment(attrs: &[Attribute]) -> Vec<String> {
+    let mut lines = vec![];
+    for attr in attrs {
+        if let Meta::NameValue(MetaNameValue { path, value, .. }) = &attr.meta {
+            if path.is_ident("doc") {
+                if let Expr::Lit(ExprLit {
+                    lit: Lit::Str(lit_str),
+                    ..
+                }) = value
+                {
+                    lines.push(lit_str.value().trim().to_string());
+                }
+            }
+        }
+    }
+    lines
+}
+
+fn parse_metrics_name(attrs: &[Attribute]) -> Option<String> {
+    for attr in attrs {
+        if let Meta::List(MetaList { path, tokens, .. }) = &attr.meta {
+            if path.is_ident("metrics") {
+                let parser = syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated;
+                if let Ok(parsed) = parser.parse2(tokens.clone()) {
+                    for meta in parsed {
+                        if let Meta::NameValue(MetaNameValue {
+                            path,
+                            value:
+                                Expr::Lit(ExprLit {
+                                    lit: Lit::Str(lit_str),
+                                    ..
+                                }),
+                            ..
+                        }) = meta
+                        {
+                            if path.is_ident("name") {
+                                return Some(lit_str.value());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}

--- a/iroh-metrics-derive/src/lib.rs
+++ b/iroh-metrics-derive/src/lib.rs
@@ -78,7 +78,7 @@ fn impl_metrics(input: &DeriveInput) -> proc_macro2::TokenStream {
         let field_name = field.ident.as_ref().unwrap();
         let ty = &field.ty;
         let doc = parse_doc_comment(&field.attrs)
-            .get(0)
+            .first()
             .cloned()
             .unwrap_or_else(|| field_name.to_string());
         fields_impl = quote! {
@@ -107,7 +107,7 @@ fn impl_metrics(input: &DeriveInput) -> proc_macro2::TokenStream {
     }
 }
 
-fn parse_doc_comment<'a>(attrs: &'a [Attribute]) -> Vec<String> {
+fn parse_doc_comment(attrs: &[Attribute]) -> Vec<String> {
     let mut lines = vec![];
     for attr in attrs {
         if let Meta::NameValue(MetaNameValue { path, value, .. }) = &attr.meta {

--- a/iroh-metrics-derive/src/lib.rs
+++ b/iroh-metrics-derive/src/lib.rs
@@ -60,13 +60,13 @@ fn expand_metrics(input: &DeriveInput) -> Result<proc_macro2::TokenStream, Error
         let field_name = field.ident.as_ref().unwrap();
         let ty = &field.ty;
         let attr = parse_metrics_attr(&field.attrs)?;
-        let description = attr
-            .description
+        let help = attr
+            .help
             .or_else(|| parse_doc_first_line(&field.attrs))
             .unwrap_or_else(|| field_name.to_string());
 
         field_defaults.extend(quote! {
-            #field_name: #ty::new(#description),
+            #field_name: #ty::new(#help),
         });
     }
 
@@ -109,7 +109,7 @@ fn parse_doc_first_line(attrs: &[Attribute]) -> Option<String> {
 #[derive(Default)]
 struct MetricsAttr {
     name: Option<String>,
-    description: Option<String>,
+    help: Option<String>,
 }
 
 fn parse_metrics_attr(attrs: &[Attribute]) -> Result<MetricsAttr, syn::Error> {
@@ -119,12 +119,12 @@ fn parse_metrics_attr(attrs: &[Attribute]) -> Result<MetricsAttr, syn::Error> {
             if meta.path.is_ident("name") {
                 out.name = Some(parse_lit_str(&meta)?);
                 Ok(())
-            } else if meta.path.is_ident("description") {
-                out.description = Some(parse_lit_str(&meta)?);
+            } else if meta.path.is_ident("help") {
+                out.help = Some(parse_lit_str(&meta)?);
                 Ok(())
             } else {
                 Err(meta.error(
-                    "The `metrics` attribute supports only `name` and `description` fields.",
+                    "The `metrics` attribute supports only `name` and `help` fields.",
                 ))
             }
         })?;

--- a/iroh-metrics-derive/src/lib.rs
+++ b/iroh-metrics-derive/src/lib.rs
@@ -37,7 +37,7 @@ fn expand_iterable(input: &DeriveInput) -> Result<proc_macro2::TokenStream, Erro
     }
 
     Ok(quote! {
-        impl ::iroh_metrics::Iterable for #name {
+        impl ::iroh_metrics::iterable::Iterable for #name {
             fn field_count(&self) -> usize {
                 #count
             }

--- a/src/base.rs
+++ b/src/base.rs
@@ -5,7 +5,7 @@ pub use prometheus_client::registry::Registry;
 
 use crate::{
     iterable::{FieldIter, IntoIterable, Iterable},
-    Counter, Gauge, Metric,
+    Metric,
 };
 
 /// Trait for structs containing metric items.
@@ -15,6 +15,7 @@ pub trait MetricsGroup:
     /// Registers all metric items in this metrics group to a [`prometheus_client::registry::Registry`].
     #[cfg(feature = "metrics")]
     fn register(&self, registry: &mut prometheus_client::registry::Registry) {
+        use crate::{Counter, Gauge};
         let sub_registry = registry.sub_registry_with_prefix(self.name());
         for item in self.iter() {
             if let Some(counter) = item.as_any().downcast_ref::<Counter>() {
@@ -107,7 +108,7 @@ pub trait MetricsGroupSet {
 /// All ops are noops then, get always returns 0.
 #[cfg(all(test, not(feature = "metrics")))]
 mod tests {
-    use super::Counter;
+    use crate::Counter;
 
     #[test]
     fn test() {
@@ -121,7 +122,7 @@ mod tests {
 #[cfg(all(test, feature = "metrics"))]
 mod tests {
     use super::*;
-    use crate::{iterable::Iterable, MetricType};
+    use crate::{iterable::Iterable, Counter, Gauge, MetricType};
 
     #[derive(Debug, Clone, Iterable)]
     pub struct FooMetrics {

--- a/src/base.rs
+++ b/src/base.rs
@@ -1,3 +1,5 @@
+use std::any::Any;
+
 #[cfg(feature = "metrics")]
 pub use prometheus_client::registry::Registry;
 
@@ -5,8 +7,6 @@ use crate::{
     metrics::{Counter, Gauge},
     FieldIter, IntoIterable, Iterable, MetricType,
 };
-
-use std::any::Any;
 /// Description of a group of metrics.
 pub trait MetricsGroup:
     Any + Iterable + IntoIterable + std::fmt::Debug + 'static + Send + Sync
@@ -206,9 +206,8 @@ mod tests {
 /// Tests with the `metrics` feature,
 #[cfg(all(test, feature = "metrics"))]
 mod tests {
-    use crate::Iterable;
-
     use super::*;
+    use crate::Iterable;
 
     #[derive(Debug, Clone, Iterable)]
     pub struct FooMetrics {

--- a/src/base.rs
+++ b/src/base.rs
@@ -373,7 +373,7 @@ combined_bar_count_total 10
         use crate::{MetricValue, MetricsGroup};
 
         #[derive(Debug, Clone, MetricsGroup)]
-        #[metrics(name = "my-metrics")]
+        #[metrics_group(name = "my-metrics")]
         struct Metrics {
             /// Counts foos
             ///
@@ -386,16 +386,16 @@ combined_bar_count_total 10
         }
 
         let metrics = Metrics::default();
+        assert_eq!(metrics.name(), "my-metrics");
 
         metrics.foo.inc();
         metrics.bar.inc_by(2);
         metrics.baz.set(3);
 
-        let values: Vec<_> = metrics.values().collect();
-        let foo = values[0];
-        let bar = values[1];
-        let baz = values[2];
-        assert_eq!(metrics.name(), "my-metrics");
+        let mut values = metrics.values();
+        let foo = values.next().unwrap();
+        let bar = values.next().unwrap();
+        let baz = values.next().unwrap();
         assert_eq!(foo.value, MetricValue::Counter(1));
         assert_eq!(foo.name, "foo");
         assert_eq!(foo.description, "Counts foos");
@@ -410,5 +410,7 @@ combined_bar_count_total 10
         struct FooMetrics {}
         let metrics = FooMetrics::default();
         assert_eq!(metrics.name(), "foo_metrics");
+        let mut values = metrics.values();
+        assert_eq!(values.next(), None);
     }
 }

--- a/src/base.rs
+++ b/src/base.rs
@@ -306,7 +306,7 @@ combined_bar_count_total 10
         use crate::{MetricValue, MetricsGroup};
 
         #[derive(Debug, Clone, MetricsGroup)]
-        #[metrics_group(name = "my-metrics")]
+        #[metrics(name = "my-metrics")]
         struct Metrics {
             /// Counts foos
             ///
@@ -314,7 +314,8 @@ combined_bar_count_total 10
             foo: Counter,
             // no description: use field name as description
             bar: Counter,
-            /// Measures baz
+            /// This docstring is not used as prometheus description
+            #[metrics(description = "Measures baz")]
             baz: Gauge,
         }
 

--- a/src/iterable.rs
+++ b/src/iterable.rs
@@ -1,4 +1,11 @@
+//! Traits for iterating over the fields of structs.
+
 use std::fmt;
+
+/// Derives [`Iterable`] for a struct.
+///
+/// [`Iterable`]: ::iroh_metrics::Iterable
+pub use iroh_metrics_derive::Iterable;
 
 /// Trait for iterating over the fields of a struct.
 pub trait Iterable {

--- a/src/iterable.rs
+++ b/src/iterable.rs
@@ -1,0 +1,74 @@
+use std::fmt;
+
+/// Trait for iterating over the fields of a struct.
+pub trait Iterable {
+    /// Returns the number of fields in the struct.
+    fn field_count(&self) -> usize;
+    /// Returns the field name and dyn reference to the field.
+    fn field(&self, n: usize) -> Option<(&'static str, &dyn std::any::Any)>;
+}
+
+impl dyn Iterable {
+    /// Returns an iterator over the fields of the struct.
+    pub fn iter(&self) -> FieldIter<'_> {
+        FieldIter::new(self)
+    }
+}
+
+/// Helper trait to convert from `self` to `dyn Iterable`.
+pub trait IntoIterable {
+    /// Returns `self` as `dyn Iterable`
+    fn as_iterable(&self) -> &dyn Iterable;
+
+    /// Returns an iterator over the fields of the struct.
+    fn iter(&self) -> FieldIter<'_> {
+        FieldIter::new(self.as_iterable())
+    }
+}
+
+impl<T> IntoIterable for T
+where
+    T: Iterable,
+{
+    fn as_iterable(&self) -> &dyn Iterable {
+        self
+    }
+}
+
+/// Iterator over the fields of a struct.
+///
+/// Returned from [`Iterable::iter`] and [`dyn Iterable::dyn_iter`].
+pub struct FieldIter<'a> {
+    pos: usize,
+    inner: &'a dyn Iterable,
+}
+
+impl<'a> fmt::Debug for FieldIter<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "FieldIter")
+    }
+}
+
+impl<'a> FieldIter<'a> {
+    pub(crate) fn new(inner: &'a dyn Iterable) -> Self {
+        Self { pos: 0, inner }
+    }
+}
+impl<'a> Iterator for FieldIter<'a> {
+    type Item = (&'static str, &'a dyn std::any::Any);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.pos == self.inner.field_count() {
+            None
+        } else {
+            let out = self.inner.field(self.pos);
+            self.pos += 1;
+            out
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let n = self.inner.field_count() - self.pos;
+        (n, Some(n))
+    }
+}

--- a/src/iterable.rs
+++ b/src/iterable.rs
@@ -37,13 +37,13 @@ where
 
 /// Iterator over the fields of a struct.
 ///
-/// Returned from [`Iterable::iter`] and [`dyn Iterable::dyn_iter`].
+/// Returned from [`IntoIterable::iter`].
 pub struct FieldIter<'a> {
     pos: usize,
     inner: &'a dyn Iterable,
 }
 
-impl<'a> fmt::Debug for FieldIter<'a> {
+impl fmt::Debug for FieldIter<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "FieldIter")
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,8 @@ pub mod static_core;
 #[cfg(feature = "service")]
 pub mod service;
 
+extern crate self as iroh_metrics;
+
 use std::collections::HashMap;
 
 /// Potential errors from this library.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@
 /// Exposes core types and traits
 mod base;
 pub use base::*;
+#[cfg(feature = "derive")]
+pub use iroh_metrics_derive::MetricsGroup;
 
 mod metrics;
 pub use metrics::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,11 +24,13 @@ pub mod service;
 /// It will generate a [`Default`] impl which expects all fields to be of a type
 /// that has a public `new` method taking a single `&'static str` argument.
 /// The [`Default::default`] method will call each field's `new` method with the
-/// first line of the field's doc comment as argument.
+/// first line of the field's doc comment as argument. Alternatively, you can override
+/// the value passed to `new` by setting a `#[metrics(description = "my description")]`
+/// attribute on the field.
 ///
 /// It will also generate a [`MetricsGroup`] impl. By default, the struct's name,
 /// converted to `camel_case` will be used as the return value of the [`MetricsGroup::name`]
-/// method. The name can be customized by setting a `#[metrics_group(name = "my-name")]` attribute.
+/// method. The name can be customized by setting a `#[metrics(name = "my-name")]` attribute.
 ///
 /// It will also generate a [`Iterable`] impl.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,6 @@
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![cfg_attr(iroh_docsrs, feature(doc_auto_cfg))]
 
-pub use iroh_metrics_derive::{Iterable, MetricsGroup};
-
 /// Exposes core types and traits
 mod base;
 pub use base::*;
@@ -11,8 +9,7 @@ pub use base::*;
 mod metrics;
 pub use metrics::*;
 
-mod iterable;
-pub use iterable::*;
+pub mod iterable;
 
 #[cfg(feature = "static_core")]
 pub mod static_core;
@@ -20,6 +17,27 @@ pub mod static_core;
 #[cfg(feature = "service")]
 pub mod service;
 
+/// Derives [`MetricsGroup`], [`Iterable`] and [`Default`] for a struct.
+///
+/// This derive macro only works on structs with named fields.
+///
+/// It will generate a [`Default`] impl which expects all fields to be of a type
+/// that has a public `new` method taking a single `&'static str` argument.
+/// The [`Default::default`] method will call each field's `new` method with the
+/// first line of the field's doc comment as argument.
+///
+/// It will also generate a [`MetricsGroup`] impl. By default, the struct's name,
+/// converted to `camel_case` will be used as the return value of the [`MetricsGroup::name`]
+/// method. The name can be customized by setting a `#[metrics_group(name = "my-name")]` attribute.
+///
+/// It will also generate a [`Iterable`] impl.
+///
+/// [`MetricsGroup`]: ::iroh_metrics::MetricsGroup
+/// [`Iterable`]: ::iroh_metrics::Iterable
+/// [`Default`]: ::std::default::Default
+pub use iroh_metrics_derive::MetricsGroup;
+
+// This lets us use the derive metrics in the lib tests within this crate.
 extern crate self as iroh_metrics;
 
 use std::collections::HashMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,14 +2,17 @@
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![cfg_attr(iroh_docsrs, feature(doc_auto_cfg))]
 
+pub use iroh_metrics_derive::{Iterable, MetricsGroup};
+
 /// Exposes core types and traits
 mod base;
 pub use base::*;
-#[cfg(feature = "derive")]
-pub use iroh_metrics_derive::MetricsGroup;
 
 mod metrics;
 pub use metrics::*;
+
+mod iterable;
+pub use iterable::*;
 
 #[cfg(feature = "static_core")]
 pub mod static_core;
@@ -18,9 +21,6 @@ pub mod static_core;
 pub mod service;
 
 use std::collections::HashMap;
-
-/// Reexports `struct_iterable` to make matching versions easier.
-pub use struct_iterable;
 
 /// Potential errors from this library.
 #[derive(Debug, thiserror::Error)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub mod service;
 /// that has a public `new` method taking a single `&'static str` argument.
 /// The [`Default::default`] method will call each field's `new` method with the
 /// first line of the field's doc comment as argument. Alternatively, you can override
-/// the value passed to `new` by setting a `#[metrics(description = "my description")]`
+/// the value passed to `new` by setting a `#[metrics(help = "my help")]`
 /// attribute on the field.
 ///
 /// It will also generate a [`MetricsGroup`] impl. By default, the struct's name,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -20,6 +20,7 @@ pub enum MetricType {
 
 /// The value of an individual metric item.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum MetricValue {
     /// A [`Counter`] value.
     Counter(u64),

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -46,8 +46,8 @@ pub trait Metric: std::fmt::Debug {
     /// The current value of this metric.
     fn value(&self) -> MetricValue;
 
-    /// The description of this metric.
-    fn description(&self) -> &'static str;
+    /// The help string for this metric.
+    fn help(&self) -> &'static str;
 
     /// Cast this metric to [`Any`] for downcasting to concrete types.
     fn as_any(&self) -> &dyn Any;
@@ -62,7 +62,7 @@ pub struct Counter {
     #[cfg(feature = "metrics")]
     pub(crate) counter: prometheus_client::metrics::counter::Counter,
     /// What this counter measures.
-    description: &'static str,
+    help: &'static str,
 }
 
 impl Metric for Counter {
@@ -74,8 +74,8 @@ impl Metric for Counter {
         MetricType::Counter
     }
 
-    fn description(&self) -> &'static str {
-        self.description
+    fn help(&self) -> &'static str {
+        self.help
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -84,12 +84,12 @@ impl Metric for Counter {
 }
 
 impl Counter {
-    /// Constructs a new counter, based on the given `description`.
-    pub fn new(description: &'static str) -> Self {
+    /// Constructs a new counter, based on the given `help`.
+    pub fn new(help: &'static str) -> Self {
         Counter {
             #[cfg(feature = "metrics")]
             counter: Default::default(),
-            description,
+            help,
         }
     }
 
@@ -150,7 +150,7 @@ pub struct Gauge {
     #[cfg(feature = "metrics")]
     pub(crate) gauge: prometheus_client::metrics::gauge::Gauge,
     /// What this gauge tracks.
-    description: &'static str,
+    help: &'static str,
 }
 
 impl Metric for Gauge {
@@ -158,8 +158,8 @@ impl Metric for Gauge {
         MetricType::Gauge
     }
 
-    fn description(&self) -> &'static str {
-        self.description
+    fn help(&self) -> &'static str {
+        self.help
     }
 
     fn value(&self) -> MetricValue {
@@ -172,12 +172,12 @@ impl Metric for Gauge {
 }
 
 impl Gauge {
-    /// Constructs a new gauge, based on the given `description`.
-    pub fn new(description: &'static str) -> Self {
+    /// Constructs a new gauge, based on the given `help`.
+    pub fn new(help: &'static str) -> Self {
         Self {
             #[cfg(feature = "metrics")]
             gauge: Default::default(),
-            description,
+            help,
         }
     }
 

--- a/src/static_core.rs
+++ b/src/static_core.rs
@@ -10,7 +10,7 @@
 //!
 //! # Example:
 //! ```rust
-//! use iroh_metrics::{inc, inc_by, static_core::Core, Iterable, Counter, MetricsGroup};
+//! use iroh_metrics::{inc, inc_by, static_core::Core, Counter, Iterable, MetricsGroup};
 //!
 //! #[derive(Debug, Clone, Iterable)]
 //! pub struct Metrics {

--- a/src/static_core.rs
+++ b/src/static_core.rs
@@ -10,8 +10,7 @@
 //!
 //! # Example:
 //! ```rust
-//! use iroh_metrics::{inc, inc_by, static_core::Core, Counter, MetricsGroup};
-//! use struct_iterable::Iterable;
+//! use iroh_metrics::{inc, inc_by, static_core::Core, Iterable, Counter, MetricsGroup};
 //!
 //! #[derive(Debug, Clone, Iterable)]
 //! pub struct Metrics {

--- a/src/static_core.rs
+++ b/src/static_core.rs
@@ -10,7 +10,7 @@
 //!
 //! # Example:
 //! ```rust
-//! use iroh_metrics::{inc, inc_by, static_core::Core, Counter, Iterable, MetricsGroup};
+//! use iroh_metrics::{inc, inc_by, iterable::Iterable, static_core::Core, Counter, MetricsGroup};
 //!
 //! #[derive(Debug, Clone, Iterable)]
 //! pub struct Metrics {


### PR DESCRIPTION
## Description

* Adds a `Metric` trait that is implemented on `Gauge` and `Counter` to provide a common interface.
* Adds a custom trait and derive macro `Iterable` that works similar to `struct_iterable`, but returns an iterator over `&dyn Metric` and does not allocate for iteration.
* Adds a derive macro `MetricsGroup` that expands to the `Iterable` impl and also implements `Default` by calling `FieldType::new(description)` for each field, where `description` is the first line of the field's doc comment, or a custom string set via `#[metrics(description = "my description")]`. Also implements `MetricsGroup`, with a `name` of either the struct name converted to camel_case, or a custom name set via `#[metrics_group(name = "my_name")]`
* Simplifies the iterators over `MetricsGroup` and `MetricsGroupSet` by using the new `Metric` trait and the dyn field iterator from the derived  `Iterable` impl
* Removes the `MetricDescription` types, those are not needed anymore.

## Breaking Changes

* `struct_iterable::Iterable` is no longer exported from `iroh-metrics`, and is no longer a supertrait of `MetricsGroup`
* instead, `MetricsGroup` now has `iroh_metrics::Iterable` and `iroh_metrics::IntoIterable` supertraits. They can be implemented manually, but it is recommended to use the new `MetricsGroup` or `Iterable` derive macros exported from `iroh_metrics`. See their docs for details.
* `MetricsGroupSet::iter` is renamed to  `MetricsGroupSet::groups`
* `MetricsGroup::values` and `MetricsGroup::describe` are removed. Use `MetricsGroup::iter` instead.
* `MetricItem` struct changed, but still provides access to the same data, through the `name()` method and its deref to `&dyn Metric`.
* `MetricDescription` is removed, everything there is now accessible over `MetricItem` through `MetricsGroup::iter`.

## Notes & open questions
<!-- Any notes, remarks or open questions you have to make about the PR. -->
## Change checklist
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.