### PR TITLE
ci: update sccache-action to 0.0.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -157,7 +157,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.7
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Setup Environment (PR)
         if: ${{ github.event_name == 'pull_request' }}
@@ -189,7 +189,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: rustfmt
-    - uses: mozilla-actions/sccache-action@v0.0.7
+    - uses: mozilla-actions/sccache-action@v0.0.9
     - uses: taiki-e/install-action@cargo-make
     - run: cargo make format-check
 
@@ -206,7 +206,7 @@ jobs:
       with:
         toolchain: nightly-2024-11-30
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.7
+      uses: mozilla-actions/sccache-action@v0.0.9
 
     - name: Docs
       run: cargo doc --workspace --all-features --no-deps --document-private-items
@@ -225,7 +225,7 @@ jobs:
       with:
         components: clippy
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.7
+      uses: mozilla-actions/sccache-action@v0.0.9
 
     # TODO: We have a bunch of platform-dependent code so should
     #    probably run this job on the full platform matrix
@@ -252,7 +252,7 @@ jobs:
       with:
         toolchain: ${{ env.MSRV }}
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.7
+      uses: mozilla-actions/sccache-action@v0.0.9
 
     - name: Check MSRV all features
       run: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -34,7 +34,7 @@ jobs:
       with:
         toolchain: nightly-2024-11-30
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.7
+      uses: mozilla-actions/sccache-action@v0.0.9
 
     - name: Generate Docs
       run: cargo doc --workspace --all-features --no-deps

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -69,7 +69,7 @@ jobs:
         tool: nextest
 
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.7
+      uses: mozilla-actions/sccache-action@v0.0.9
 
     - name: Select features
       run: |
@@ -111,7 +111,7 @@ jobs:
     - name: list ignored tests
       run: |
         cargo nextest list --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ignored-only
-      env: 
+      env:
         NEXTEST_NO_TESTS: "pass"
 
     - name: run tests
@@ -202,7 +202,7 @@ jobs:
         }
 
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.7
+      uses: mozilla-actions/sccache-action@v0.0.9
 
     - uses: msys2/setup-msys2@v2
 
@@ -224,7 +224,7 @@ jobs:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
         NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
         NEXTEST_NO_TESTS: "pass"
-  
+
     - name: upload results
       if: ${{ failure() && inputs.flaky }}
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Needed because of https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts