### PR TITLE
feat: Add derive for `MetricsGroupSet`

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -99,7 +99,9 @@ mod tests {
     use serde::{Deserialize, Serialize};
 
     use super::*;
-    use crate::{iterable::Iterable, Counter, Gauge, MetricType, MetricsSource, Registry};
+    use crate::{
+        iterable::Iterable, Counter, Gauge, MetricType, MetricsGroupSet, MetricsSource, Registry,
+    };
 
     #[derive(Debug, Iterable, Serialize, Deserialize)]
     pub struct FooMetrics {
@@ -134,13 +136,22 @@ mod tests {
         }
     }
 
-    #[derive(Debug, Default, Serialize, Deserialize)]
+    #[derive(Debug, Default, Serialize, Deserialize, MetricsGroupSet)]
+    #[metrics(name = "combined")]
     struct CombinedMetrics {
         foo: Arc<FooMetrics>,
         bar: Arc<BarMetrics>,
     }
 
-    impl MetricsGroupSet for CombinedMetrics {
+    // Making sure it is reasonably possible to write the trait impl ourselves.
+    #[allow(unused)]
+    #[derive(Debug, Default)]
+    struct CombinedMetricsManual {
+        foo: Arc<FooMetrics>,
+        bar: Arc<BarMetrics>,
+    }
+
+    impl MetricsGroupSet for CombinedMetricsManual {
         fn name(&self) -> &'static str {
             "combined"
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,11 @@ pub mod static_core;
 ///
 /// [`Iterable`]: iterable::Iterable
 pub use iroh_metrics_derive::MetricsGroup;
+/// Derives [`MetricsGroupSet`] for a struct.
+///
+/// All fields of the struct must be public and have a type of `Arc<SomeType>`,
+/// where `SomeType` implements `MetricsGroup`.
+pub use iroh_metrics_derive::MetricsGroupSet;
 
 // This lets us use the derive metrics in the lib tests within this crate.
 extern crate self as iroh_metrics;


### PR DESCRIPTION
## Description

* Adds a derive macro for `MetricsGroupSet`

Based on #22

## Breaking Changes
<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->
## Notes & open questions
<!-- Any notes, remarks or open questions you have to make about the PR. -->
## Change checklist
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.