### PR TITLE
refactor!: replace thiserror with snafu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,7 +490,7 @@ dependencies = [
  "postcard",
  "reqwest",
  "serde",
- "thiserror",
+ "snafu",
  "tokio",
  "tracing",
 ]
@@ -938,6 +938,27 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "snafu"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "223891c85e2a29c3fe8fb900c1fae5e69c2e42415e3177752e8718475efa5019"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ unused-async = "warn"
 iroh-metrics-derive = { path = "./iroh-metrics-derive", version = "0.1.0" }
 itoa = "1"
 serde = { version = "1", features = ["derive", "rc"] }
-thiserror = "2.0.6"
+snafu = { version = "0.8.5", features = ["rust_1_81"] }
 tracing = "0.1"
 
 # static_core feature

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,19 +45,28 @@ extern crate self as iroh_metrics;
 
 use std::collections::HashMap;
 
+use snafu::{Backtrace, Snafu};
+
 /// Potential errors from this library.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Snafu)]
 #[non_exhaustive]
+#[allow(missing_docs)]
 pub enum Error {
     /// Indicates that the metrics have not been enabled.
-    #[error("Metrics not enabled")]
-    NoMetrics,
+    #[snafu(display("Metrics not enabled"))]
+    NoMetrics { backtrace: Option<Backtrace> },
     /// Writing the metrics to the output buffer failed.
-    #[error("Writing the metrics to the output buffer failed")]
-    Fmt(#[from] std::fmt::Error),
+    #[snafu(transparent)]
+    Fmt {
+        source: std::fmt::Error,
+        backtrace: Option<Backtrace>,
+    },
     /// Any IO related error.
-    #[error("IO: {0}")]
-    Io(#[from] std::io::Error),
+    #[snafu(transparent)]
+    IO {
+        source: std::io::Error,
+        backtrace: Option<Backtrace>,
+    },
 }
 
 /// Parses Prometheus metrics from a string.

--- a/src/static_core.rs
+++ b/src/static_core.rs
@@ -35,7 +35,7 @@ use std::sync::OnceLock;
 
 use erased_set::ErasedSyncSet;
 
-use crate::{Error, MetricsGroup, Registry};
+use crate::{Error, MetricsGroup, NoMetricsSnafu, Registry};
 
 #[cfg(not(feature = "metrics"))]
 type Registry = ();
@@ -48,9 +48,7 @@ pub struct GlobalRegistry;
 
 impl crate::MetricsSource for GlobalRegistry {
     fn encode_openmetrics(&self, writer: &mut impl std::fmt::Write) -> Result<(), Error> {
-        let core = crate::static_core::Core::get().ok_or(Error::NoMetrics {
-            backtrace: Some(snafu::Backtrace::capture()),
-        })?;
+        let core = crate::static_core::Core::get().ok_or(NoMetricsSnafu.build())?;
         core.registry.encode_openmetrics(writer)
     }
 }

--- a/src/static_core.rs
+++ b/src/static_core.rs
@@ -35,7 +35,7 @@ use std::sync::OnceLock;
 
 use erased_set::ErasedSyncSet;
 
-use crate::{base::MetricsGroup, Error, Registry};
+use crate::{Error, MetricsGroup, Registry};
 
 #[cfg(not(feature = "metrics"))]
 type Registry = ();

--- a/src/static_core.rs
+++ b/src/static_core.rs
@@ -48,7 +48,9 @@ pub struct GlobalRegistry;
 
 impl crate::MetricsSource for GlobalRegistry {
     fn encode_openmetrics(&self, writer: &mut impl std::fmt::Write) -> Result<(), Error> {
-        let core = crate::static_core::Core::get().ok_or(Error::NoMetrics)?;
+        let core = crate::static_core::Core::get().ok_or(Error::NoMetrics {
+            backtrace: Some(snafu::Backtrace::capture()),
+        })?;
         core.registry.encode_openmetrics(writer)
     }
 }


### PR DESCRIPTION
## Description

This replaces `thiserror` with `snafu`.

## Breaking Changes

* `iroh_metrics::Error` changed to include backtraces in variants, and it now derives `std::error::Error` via `snafu` instead of via `thiserror`.

## Notes & open questions
<!-- Any notes, remarks or open questions you have to make about the PR. -->
## Change checklist
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.