### PR TITLE
chore: add ignore to deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -21,4 +21,6 @@ expression = "MIT AND ISC AND OpenSSL"
 license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 
 [advisories]
-ignore = []
+ignore = [
+  "RUSTSEC-2023-0089", # unmainatined: postcard -> heapless -> atomic-polyfill
+]


### PR DESCRIPTION
## Description

for unmaintained dependency atomic-polyfill of postcard through heapless.

See https://github.com/jamesmunns/postcard/issues/223
