### PR TITLE
feat: allow to encode a registry in openmetrics without EOF

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -83,8 +83,8 @@ impl Registry {
 
     /// Encodes all metrics in the OpenMetrics text format.
     ///
-    /// Note that this does not add the EOF marker to the output. Use [`encode_openmetrics_eof`]
-    /// to do that.
+    /// This does not write the terminal `# EOF\n` string to `writer`.
+    /// You can use [`encode_openmetrics_eof`] to do that.
     pub fn encode_openmetrics_to_writer(&self, writer: &mut impl Write) -> fmt::Result {
         for group in &self.metrics {
             group.encode_openmetrics(writer, self.prefix.as_deref(), &self.labels)?;
@@ -107,9 +107,14 @@ pub fn encode_openmetrics_eof(writer: &mut impl Write) -> fmt::Result {
 /// Helper trait to abstract over different ways to access metrics.
 pub trait MetricsSource: Send + 'static {
     /// Encodes all metrics into a string in the OpenMetrics text format.
+    ///
+    /// This is expected to also write the terminal `# EOF\n` string expected
+    /// by the OpenMetrics format.
     fn encode_openmetrics(&self, writer: &mut impl std::fmt::Write) -> Result<(), Error>;
 
     /// Encodes the metrics in the OpenMetrics text format into a newly allocated string.
+    ///
+    /// See also [`Self::encode_openmetrics`].
     fn encode_openmetrics_to_string(&self) -> Result<String, Error> {
         let mut s = String::new();
         self.encode_openmetrics(&mut s)?;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -81,16 +81,27 @@ impl Registry {
         registry.register_all(metrics_group_set)
     }
 
-    fn encode_inner(&self, writer: &mut impl Write) -> fmt::Result {
+    /// Encodes all metrics in the OpenMetrics text format.
+    ///
+    /// Note that this does not add the EOF marker to the output. Use [`encode_openmetrics_eof`]
+    /// to do that.
+    pub fn encode_openmetrics(&self, writer: &mut impl Write) -> fmt::Result {
         for group in &self.metrics {
             group.encode_openmetrics(writer, self.prefix.as_deref(), &self.labels)?;
         }
 
         for sub in self.sub_registries.iter() {
-            sub.encode_inner(writer)?;
+            sub.encode_openmetrics(writer)?;
         }
         Ok(())
     }
+}
+
+/// Writes `# EOF\n` to `writer`.
+///
+/// This is the expected last characters of an OpenMetrics string.
+pub fn encode_openmetrics_eof(writer: &mut impl Write) -> fmt::Result {
+    write_eof(writer)
 }
 
 /// Helper trait to abstract over different ways to access metrics.
@@ -108,7 +119,7 @@ pub trait MetricsSource: Send + 'static {
 
 impl MetricsSource for Registry {
     fn encode_openmetrics(&self, writer: &mut impl std::fmt::Write) -> Result<(), Error> {
-        self.encode_inner(writer)?;
+        self.encode_openmetrics(writer)?;
         write_eof(writer)?;
         Ok(())
     }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -85,13 +85,13 @@ impl Registry {
     ///
     /// Note that this does not add the EOF marker to the output. Use [`encode_openmetrics_eof`]
     /// to do that.
-    pub fn encode_openmetrics(&self, writer: &mut impl Write) -> fmt::Result {
+    pub fn encode_openmetrics_to_writer(&self, writer: &mut impl Write) -> fmt::Result {
         for group in &self.metrics {
             group.encode_openmetrics(writer, self.prefix.as_deref(), &self.labels)?;
         }
 
         for sub in self.sub_registries.iter() {
-            sub.encode_openmetrics(writer)?;
+            sub.encode_openmetrics_to_writer(writer)?;
         }
         Ok(())
     }
@@ -119,7 +119,7 @@ pub trait MetricsSource: Send + 'static {
 
 impl MetricsSource for Registry {
     fn encode_openmetrics(&self, writer: &mut impl std::fmt::Write) -> Result<(), Error> {
-        self.encode_openmetrics(writer)?;
+        self.encode_openmetrics_to_writer(writer)?;
         write_eof(writer)?;
         Ok(())
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -2,7 +2,6 @@
 
 use std::{
     net::SocketAddr,
-    ops::Deref,
     sync::{Arc, RwLock},
     time::{Duration, Instant},
 };
@@ -24,13 +23,13 @@ pub type RwLockRegistry = Arc<RwLock<Registry>>;
 impl MetricsSource for RwLockRegistry {
     fn encode_openmetrics(&self, writer: &mut impl std::fmt::Write) -> Result<(), Error> {
         let inner = self.read().expect("poisoned");
-        inner.encode_openmetrics(writer)
+        <Registry as MetricsSource>::encode_openmetrics(&inner, writer)
     }
 }
 
 impl MetricsSource for Arc<Registry> {
     fn encode_openmetrics(&self, writer: &mut impl std::fmt::Write) -> Result<(), Error> {
-        Arc::deref(self).encode_openmetrics(writer)
+        <Registry as MetricsSource>::encode_openmetrics(self, writer)
     }
 }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -2,6 +2,7 @@
 
 use std::{
     net::SocketAddr,
+    ops::Deref,
     sync::{Arc, RwLock},
     time::{Duration, Instant},
 };
@@ -23,13 +24,13 @@ pub type RwLockRegistry = Arc<RwLock<Registry>>;
 impl MetricsSource for RwLockRegistry {
     fn encode_openmetrics(&self, writer: &mut impl std::fmt::Write) -> Result<(), Error> {
         let inner = self.read().expect("poisoned");
-        <Registry as MetricsSource>::encode_openmetrics(&inner, writer)
+        inner.encode_openmetrics(writer)
     }
 }
 
 impl MetricsSource for Arc<Registry> {
     fn encode_openmetrics(&self, writer: &mut impl std::fmt::Write) -> Result<(), Error> {
-        <Registry as MetricsSource>::encode_openmetrics(self, writer)
+        Arc::deref(self).encode_openmetrics(writer)
     }
 }
 

--- a/src/static_core.rs
+++ b/src/static_core.rs
@@ -35,7 +35,7 @@ use std::sync::OnceLock;
 
 use erased_set::ErasedSyncSet;
 
-use crate::{Error, MetricsGroup, NoMetricsSnafu, Registry};
+use crate::{Error, MetricsGroup, MetricsSource, NoMetricsSnafu, Registry};
 
 #[cfg(not(feature = "metrics"))]
 type Registry = ();
@@ -46,10 +46,10 @@ type Registry = ();
 #[derive(Clone, Copy, Debug)]
 pub struct GlobalRegistry;
 
-impl crate::MetricsSource for GlobalRegistry {
+impl MetricsSource for GlobalRegistry {
     fn encode_openmetrics(&self, writer: &mut impl std::fmt::Write) -> Result<(), Error> {
         let core = crate::static_core::Core::get().ok_or(NoMetricsSnafu.build())?;
-        core.registry.encode_openmetrics(writer)
+        <Registry as MetricsSource>::encode_openmetrics(&core.registry, writer)
     }
 }
 

--- a/src/static_core.rs
+++ b/src/static_core.rs
@@ -86,7 +86,7 @@ impl Core {
             #[cfg(feature = "metrics")]
             registry,
         })
-        .map_err(|_| std::io::Error::new(std::io::ErrorKind::Other, "already set"))
+        .map_err(|_| std::io::Error::other("already set"))
     }
 
     /// Returns a reference to the core metrics.

--- a/src/static_core.rs
+++ b/src/static_core.rs
@@ -49,7 +49,7 @@ pub struct GlobalRegistry;
 impl MetricsSource for GlobalRegistry {
     fn encode_openmetrics(&self, writer: &mut impl std::fmt::Write) -> Result<(), Error> {
         let core = crate::static_core::Core::get().ok_or(NoMetricsSnafu.build())?;
-        <Registry as MetricsSource>::encode_openmetrics(&core.registry, writer)
+        core.registry.encode_openmetrics(writer)
     }
 }
 


### PR DESCRIPTION
## Description

`MetricsSource::encode_openmetrics` adds the `# EOF\n` marker at the end of the encoded openmetrics output. This is the expected last characters in the openmetrics text format. Currently, `MetricsSource::encode_openmetrics` is the only public API to encode a `iroh_metrics::Registry` into the openmetrics text format.

When combining output from different sources, users should be able to add the EOF marker themselves. This PR adds a public function `Registry::encode_openmetrics_to_writer` that encodes without the EOF.

For 1.0 we should revisit the MetricsSource trait, but the change in this PR is semver compatible so can be in a patch release, so that downstream users of `iroh@0.35` can make use of it.

## Breaking Changes
<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->
## Notes & open questions
<!-- Any notes, remarks or open questions you have to make about the PR. -->
## Change checklist
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.