### PR TITLE
feat: add efficient metrics encoder that transfers schema only on change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ hyper = { version = "1", features = ["server", "http1"], optional = true }
 hyper-util = { version = "0.1.1", features = ["tokio"], optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
 tokio = { version = "1", features = ["rt", "net", "fs"], optional = true }
-postcard = "1.1.1"
+postcard = { version = "1.1.1", features = ["use-std"] }
 
 [dev-dependencies]
 postcard = { version = "1.1.1", features = ["use-std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ hyper = { version = "1", features = ["server", "http1"], optional = true }
 hyper-util = { version = "0.1.1", features = ["tokio"], optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
 tokio = { version = "1", features = ["rt", "net", "fs"], optional = true }
+postcard = "1.1.1"
 
 [dev-dependencies]
 postcard = { version = "1.1.1", features = ["use-std"] }

--- a/src/base.rs
+++ b/src/base.rs
@@ -1,8 +1,9 @@
 use std::{any::Any, sync::Arc};
 
 use crate::{
+    encoding::EncodableMetric,
     iterable::{FieldIter, IntoIterable, Iterable},
-    EncodableMetric, Metric, MetricType, MetricValue,
+    Metric, MetricType, MetricValue,
 };
 
 /// Trait for structs containing metric items.
@@ -427,7 +428,7 @@ combined_bar_count_total{x="y"} 10
 
         let mut encoder = Encoder::new_with_opts(
             registry.clone(),
-            crate::EncoderOpts {
+            crate::encoding::EncoderOpts {
                 include_help: false,
             },
         );

--- a/src/base.rs
+++ b/src/base.rs
@@ -423,7 +423,7 @@ combined_bar_count_total{x="y"} 10
         assert_eq!(om_from_decoder, om_from_registry);
 
         for item in decoder.iter() {
-            assert!(matches!(item.help, Some(_)));
+            assert!(item.help.is_some());
         }
 
         let mut encoder = Encoder::new_with_opts(

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -16,6 +16,13 @@ pub(crate) fn write_eof(writer: &mut impl Write) -> fmt::Result {
     writer.write_str("# EOF\n")
 }
 
+/// Writes `# EOF\n` to `writer`.
+///
+/// This is the expected last characters of an OpenMetrics string.
+pub fn encode_openmetrics_eof(writer: &mut impl Write) -> fmt::Result {
+    write_eof(writer)
+}
+
 /// Schema information for a single metric item.
 ///
 /// Contains metadata about a metric including its type, name, help text,

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -36,6 +36,19 @@ pub struct ItemSchema {
     pub labels: Vec<(String, String)>,
 }
 
+impl ItemSchema {
+    /// Returns the name prefixed with all prefixes.
+    pub fn prefixed_name(&self) -> String {
+        let mut out = String::new();
+        for prefix in &self.prefixes {
+            out.push_str(prefix);
+            out.push('_');
+        }
+        out.push_str(&self.name);
+        out
+    }
+}
+
 /// A collection of metric schemas.
 ///
 /// Contains all the schema information for a set of metrics.

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -361,7 +361,7 @@ impl dyn MetricsGroup {
 }
 
 /// Trait for types that can provide metric encoding information.
-pub trait EncodableMetric {
+pub(crate) trait EncodableMetric {
     /// Returns the name of this metric item.
     fn name(&self) -> &str;
 

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -255,7 +255,7 @@ impl dyn MetricsGroup {
         }
     }
 
-    pub(crate) fn encode_values<'a>(&self, values: &mut Values) {
+    pub(crate) fn encode_values(&self, values: &mut Values) {
         for metric in self.iter() {
             metric.encode_value(values);
         }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -2,18 +2,205 @@
 //!
 //! [OpenMetrics text format]: https://github.com/prometheus/OpenMetrics/blob/main/specification/OpenMetrics.md
 
+#![allow(missing_docs)]
+
 use std::{
     borrow::Cow,
     fmt::{self, Write},
+    sync::{Arc, RwLock},
 };
 
-use crate::{MetricItem, MetricType, MetricValue, MetricsGroup};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    MetricItem, MetricType, MetricValue, MetricsGroup, MetricsSource, Registry, RwLockRegistry,
+};
 
 pub(crate) fn write_eof(writer: &mut impl Write) -> fmt::Result {
     writer.write_str("# EOF\n")
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ItemSchema {
+    pub r#type: MetricType,
+    pub name: String,
+    pub help: String,
+    pub prefixes: Vec<String>,
+    pub labels: Vec<(String, String)>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct Schema {
+    pub items: Vec<ItemSchema>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct Values {
+    pub items: Vec<MetricValue>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct Update {
+    pub schema: Option<Schema>,
+    pub values: Values,
+}
+
+#[derive(Debug)]
+pub struct Item<'a> {
+    pub schema: &'a ItemSchema,
+    pub value: &'a MetricValue,
+}
+
+impl<'a> Item<'a> {
+    fn as_metric_item(&self) -> MetricItem<'a> {
+        MetricItem {
+            name: &self.schema.name,
+            help: &self.schema.help,
+            metric: self.value,
+        }
+    }
+
+    pub fn encode_openmetrics(
+        &self,
+        writer: &mut impl std::fmt::Write,
+    ) -> Result<(), crate::Error> {
+        let item = self.as_metric_item();
+        item.encode_openmetrics(
+            writer,
+            self.schema.prefixes.as_slice(),
+            self.schema
+                .labels
+                .iter()
+                .map(|(a, b)| (a.as_str(), b.as_str())),
+        )?;
+        Ok(())
+    }
+}
+
+/// Decoder for metrics received from an [`Encoder`]
+///
+/// Implements [`MetricSource`] to export the decoded metrics to OpenMetrics.
+#[derive(Debug, Default)]
+pub struct Decoder {
+    schema: Option<Schema>,
+    values: Values,
+}
+
+impl Decoder {
+    pub fn import(&mut self, update: Update) {
+        if let Some(schema) = update.schema {
+            self.schema = Some(schema);
+        }
+        self.values = update.values;
+    }
+
+    pub fn import_bytes(&mut self, data: &[u8]) -> Result<(), postcard::Error> {
+        let update = postcard::from_bytes(data)?;
+        self.import(update);
+        Ok(())
+    }
+
+    pub fn iter(&self) -> DecoderIter {
+        DecoderIter {
+            pos: 0,
+            inner: self,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct DecoderIter<'a> {
+    pos: usize,
+    inner: &'a Decoder,
+}
+
+impl<'a> Iterator for DecoderIter<'a> {
+    type Item = Item<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let schema = self.inner.schema.as_ref()?.items.get(self.pos)?;
+        let value = self.inner.values.items.get(self.pos)?;
+        self.pos += 1;
+        Some(Item { schema, value })
+    }
+}
+
+impl MetricsSource for Decoder {
+    fn encode_openmetrics(&self, writer: &mut impl std::fmt::Write) -> Result<(), crate::Error> {
+        for item in self.iter() {
+            item.encode_openmetrics(writer)?;
+        }
+        write_eof(writer)?;
+        Ok(())
+    }
+}
+
+impl MetricsSource for Arc<RwLock<Decoder>> {
+    fn encode_openmetrics(&self, writer: &mut impl std::fmt::Write) -> Result<(), crate::Error> {
+        self.read().expect("poisoned").encode_openmetrics(writer)
+    }
+}
+
+#[derive(Debug)]
+pub struct Encoder {
+    registry: Arc<RwLock<Registry>>,
+    last_schema_version: u64,
+}
+
+impl Encoder {
+    pub fn new(registry: RwLockRegistry) -> Self {
+        Self {
+            registry,
+            last_schema_version: 0,
+        }
+    }
+
+    pub fn export(&mut self) -> Update {
+        let registry = self.registry.read().expect("poisoned");
+        let current = registry.schema_version();
+        let schema = if current != self.last_schema_version {
+            self.last_schema_version = current;
+            let mut schema = Schema::default();
+            registry.encode_schema(&mut schema);
+            Some(schema)
+        } else {
+            None
+        };
+        let mut values = Values::default();
+        registry.encode_values(&mut values);
+        Update { schema, values }
+    }
+
+    pub fn export_bytes(&mut self) -> Result<Vec<u8>, postcard::Error> {
+        postcard::to_stdvec(&self.export())
+    }
+}
+
 impl dyn MetricsGroup {
+    pub(crate) fn encode_schema<'a>(
+        &self,
+        schema: &mut Schema,
+        prefix: Option<&'a str>,
+        labels: &[(Cow<'a, str>, Cow<'a, str>)],
+    ) {
+        let name = self.name();
+        let prefixes = if let Some(prefix) = prefix {
+            &[prefix, name] as &[&str]
+        } else {
+            &[name]
+        };
+        for metric in self.iter() {
+            let labels = labels.iter().map(|(k, v)| (k.as_ref(), v.as_ref()));
+            metric.encode_schema(schema, prefixes, labels);
+        }
+    }
+
+    pub(crate) fn encode_values<'a>(&self, values: &mut Values) {
+        for metric in self.iter() {
+            metric.encode_value(values);
+        }
+    }
+
     pub(crate) fn encode_openmetrics<'a>(
         &self,
         writer: &'a mut impl Write,
@@ -35,10 +222,32 @@ impl dyn MetricsGroup {
 }
 
 impl MetricItem<'_> {
+    pub(crate) fn encode_schema<'a>(
+        &self,
+        schema: &mut Schema,
+        prefixes: &[&str],
+        labels: impl Iterator<Item = (&'a str, &'a str)> + 'a,
+    ) {
+        let item = crate::encoding::ItemSchema {
+            name: self.name().to_string(),
+            prefixes: prefixes.iter().map(|s| s.to_string()).collect(),
+            help: self.help().to_string(),
+            labels: labels
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            r#type: self.r#type(),
+        };
+        schema.items.push(item);
+    }
+
+    fn encode_value(&self, values: &mut Values) {
+        values.items.push(self.value())
+    }
+
     pub(crate) fn encode_openmetrics<'a>(
         &self,
         writer: &mut impl Write,
-        prefixes: &[&str],
+        prefixes: &[impl AsRef<str>],
         labels: impl Iterator<Item = (&'a str, &'a str)> + 'a,
     ) -> fmt::Result {
         writer.write_str("# HELP ")?;
@@ -109,9 +318,13 @@ fn encode_i64(writer: &mut impl Write, v: i64) -> fmt::Result {
     Ok(())
 }
 
-fn write_prefix_name(writer: &mut impl Write, prefixes: &[&str], name: &str) -> fmt::Result {
+fn write_prefix_name(
+    writer: &mut impl Write,
+    prefixes: &[impl AsRef<str>],
+    name: &str,
+) -> fmt::Result {
     for prefix in prefixes {
-        writer.write_str(prefix)?;
+        writer.write_str(prefix.as_ref())?;
         writer.write_str("_")?;
     }
     writer.write_str(name)?;

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -122,7 +122,7 @@ impl<'a> EncodableMetric for Item<'a> {
     }
 
     fn help(&self) -> &str {
-        &self.help.map(|x| x.as_str()).unwrap_or_default()
+        self.help.map(|x| x.as_str()).unwrap_or_default()
     }
 
     fn r#type(&self) -> MetricType {
@@ -218,8 +218,7 @@ impl<'a> Iterator for DecoderIter<'a> {
             .as_ref()?
             .help
             .as_ref()
-            .map(|help| help.get(self.pos))
-            .flatten();
+            .and_then(|help| help.get(self.pos));
         self.pos += 1;
         Some(Item {
             schema,

--- a/src/iterable.rs
+++ b/src/iterable.rs
@@ -27,7 +27,7 @@ pub trait IntoIterable {
     fn as_iterable(&self) -> &dyn Iterable;
 
     /// Returns an iterator over the fields of the struct.
-    fn field_iter(&self) -> FieldIter<'_> {
+    fn field_iter(&self) -> FieldIter {
         FieldIter::new(self.as_iterable())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![cfg_attr(iroh_docsrs, feature(doc_auto_cfg))]
 
-pub use self::{base::*, metrics::*, registry::*};
+pub use self::{base::*, encoding::*, metrics::*, registry::*};
 
 mod base;
 pub(crate) mod encoding;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,10 @@
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![cfg_attr(iroh_docsrs, feature(doc_auto_cfg))]
 
-pub use self::{base::*, encoding::*, metrics::*, registry::*};
+pub use self::{base::*, metrics::*, registry::*};
 
 mod base;
-pub(crate) mod encoding;
+pub mod encoding;
 pub mod iterable;
 mod metrics;
 mod registry;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -13,7 +13,7 @@ use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use serde::{Deserialize, Serialize};
 
 /// The types of metrics supported by this crate.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum MetricType {
     /// A [`Counter`].
@@ -33,7 +33,7 @@ impl MetricType {
 }
 
 /// The value of an individual metric item.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum MetricValue {
     /// A [`Counter`] value.
@@ -57,6 +57,20 @@ impl MetricValue {
             MetricValue::Counter(_) => MetricType::Counter,
             MetricValue::Gauge(_) => MetricType::Gauge,
         }
+    }
+}
+
+impl Metric for MetricValue {
+    fn r#type(&self) -> MetricType {
+        self.r#type()
+    }
+
+    fn value(&self) -> MetricValue {
+        *self
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -83,8 +83,8 @@ impl Registry {
 
     /// Encodes all metrics in the OpenMetrics text format.
     ///
-    /// Note that this does not add the EOF marker to the output. Use [`encode_openmetrics_eof`]
-    /// to do that.
+    /// This does not write the terminal `# EOF\n` string to `writer`.
+    /// You can use [`encode_openmetrics_eof`] to do that.
     pub fn encode_openmetrics_to_writer(&self, writer: &mut impl Write) -> fmt::Result {
         for group in &self.metrics {
             group.encode_openmetrics(writer, self.prefix.as_deref(), &self.labels)?;
@@ -107,9 +107,14 @@ pub fn encode_openmetrics_eof(writer: &mut impl Write) -> fmt::Result {
 /// Helper trait to abstract over different ways to access metrics.
 pub trait MetricsSource: Send + 'static {
     /// Encodes all metrics into a string in the OpenMetrics text format.
+    ///
+    /// This is expected to also write the terminal `# EOF\n` string expected
+    /// by the OpenMetrics format.
     fn encode_openmetrics(&self, writer: &mut impl std::fmt::Write) -> Result<(), Error>;
 
     /// Encodes the metrics in the OpenMetrics text format into a newly allocated string.
+    ///
+    /// See also [`Self::encode_openmetrics`].
     fn encode_openmetrics_to_string(&self) -> Result<String, Error> {
         let mut s = String::new();
         self.encode_openmetrics(&mut s)?;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -81,16 +81,27 @@ impl Registry {
         registry.register_all(metrics_group_set)
     }
 
-    fn encode_inner(&self, writer: &mut impl Write) -> fmt::Result {
+    /// Encodes all metrics in the OpenMetrics text format.
+    ///
+    /// Note that this does not add the EOF marker to the output. Use [`encode_openmetrics_eof`]
+    /// to do that.
+    pub fn encode_openmetrics(&self, writer: &mut impl Write) -> fmt::Result {
         for group in &self.metrics {
             group.encode_openmetrics(writer, self.prefix.as_deref(), &self.labels)?;
         }
 
         for sub in self.sub_registries.iter() {
-            sub.encode_inner(writer)?;
+            sub.encode_openmetrics(writer)?;
         }
         Ok(())
     }
+}
+
+/// Writes `# EOF\n` to `writer`.
+///
+/// This is the expected last characters of an OpenMetrics string.
+pub fn encode_openmetrics_eof(writer: &mut impl Write) -> fmt::Result {
+    write_eof(writer)
 }
 
 /// Helper trait to abstract over different ways to access metrics.
@@ -108,7 +119,7 @@ pub trait MetricsSource: Send + 'static {
 
 impl MetricsSource for Registry {
     fn encode_openmetrics(&self, writer: &mut impl std::fmt::Write) -> Result<(), Error> {
-        self.encode_inner(writer)?;
+        self.encode_openmetrics(writer)?;
         write_eof(writer)?;
         Ok(())
     }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -3,7 +3,11 @@
 use std::{
     borrow::Cow,
     fmt::{self, Write},
-    sync::Arc,
+    ops::Deref,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, RwLock,
+    },
 };
 
 use crate::{encoding::write_eof, Error, MetricsGroup, MetricsGroupSet};
@@ -11,6 +15,7 @@ use crate::{encoding::write_eof, Error, MetricsGroup, MetricsGroupSet};
 /// A registry for [`MetricsGroup`].
 #[derive(Debug, Default)]
 pub struct Registry {
+    schema_version: Arc<AtomicU64>,
     metrics: Vec<Arc<dyn MetricsGroup>>,
     prefix: Option<Cow<'static, str>>,
     labels: Vec<(Cow<'static, str>, Cow<'static, str>)>,
@@ -23,7 +28,9 @@ impl Registry {
     /// Returns a mutable reference to the subregistry.
     pub fn sub_registry_with_prefix(&mut self, prefix: impl Into<Cow<'static, str>>) -> &mut Self {
         let prefix = self.prefix.to_owned().map(|p| p + "_").unwrap_or_default() + prefix.into();
+        self.schema_version.fetch_add(1, Ordering::Relaxed);
         let sub_registry = Registry {
+            schema_version: self.schema_version.clone(),
             metrics: Default::default(),
             prefix: Some(prefix),
             labels: self.labels.clone(),
@@ -42,7 +49,9 @@ impl Registry {
     ) -> &mut Self {
         let mut all_labels = self.labels.clone();
         all_labels.extend(labels.into_iter().map(|(k, v)| (k.into(), v.into())));
+        self.schema_version.fetch_add(1, Ordering::Relaxed);
         let sub_registry = Registry {
+            schema_version: self.schema_version.clone(),
             prefix: self.prefix.clone(),
             labels: all_labels,
             metrics: Default::default(),
@@ -65,6 +74,7 @@ impl Registry {
 
     /// Registers a [`MetricsGroup`] into this registry.
     pub fn register(&mut self, metrics_group: Arc<dyn MetricsGroup>) {
+        self.schema_version.fetch_add(1, Ordering::Relaxed);
         self.metrics.push(metrics_group);
     }
 
@@ -94,6 +104,33 @@ impl Registry {
             sub.encode_openmetrics_to_writer(writer)?;
         }
         Ok(())
+    }
+
+    ///
+    pub fn schema_version(&self) -> u64 {
+        self.schema_version.load(Ordering::Relaxed)
+    }
+
+    ///
+    pub fn encode_schema(&self, schema: &mut crate::encoding::Schema) {
+        for group in &self.metrics {
+            group.encode_schema(schema, self.prefix.as_deref(), &self.labels);
+        }
+
+        for sub in self.sub_registries.iter() {
+            sub.encode_schema(schema);
+        }
+    }
+
+    ///
+    pub fn encode_values(&self, values: &mut crate::encoding::Values) {
+        for group in &self.metrics {
+            group.encode_values(values);
+        }
+
+        for sub in self.sub_registries.iter() {
+            sub.encode_values(values);
+        }
     }
 }
 
@@ -127,5 +164,24 @@ impl MetricsSource for Registry {
         self.encode_openmetrics_to_writer(writer)?;
         write_eof(writer)?;
         Ok(())
+    }
+}
+
+/// A cloneable [`Registry`] in a read-write lock.
+///
+/// Useful if you need mutable access to a registry, while also using the services
+/// defined in [`crate::service`].
+pub type RwLockRegistry = Arc<RwLock<Registry>>;
+
+impl MetricsSource for RwLockRegistry {
+    fn encode_openmetrics(&self, writer: &mut impl std::fmt::Write) -> Result<(), Error> {
+        let inner = self.read().expect("poisoned");
+        inner.encode_openmetrics(writer)
+    }
+}
+
+impl MetricsSource for Arc<Registry> {
+    fn encode_openmetrics(&self, writer: &mut impl std::fmt::Write) -> Result<(), Error> {
+        Arc::deref(self).encode_openmetrics(writer)
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -134,20 +134,6 @@ impl Registry {
     }
 }
 
-/// Writes `# EOF\n` to `writer`.
-///
-/// This is the expected last characters of an OpenMetrics string.
-pub fn encode_openmetrics_eof(writer: &mut impl Write) -> fmt::Result {
-    write_eof(writer)
-}
-
-/// Writes `# EOF\n` to `writer`.
-///
-/// This is the expected last characters of an OpenMetrics string.
-pub fn encode_openmetrics_eof(writer: &mut impl Write) -> fmt::Result {
-    write_eof(writer)
-}
-
 /// Helper trait to abstract over different ways to access metrics.
 pub trait MetricsSource: Send + 'static {
     /// Encodes all metrics into a string in the OpenMetrics text format.

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -85,13 +85,13 @@ impl Registry {
     ///
     /// Note that this does not add the EOF marker to the output. Use [`encode_openmetrics_eof`]
     /// to do that.
-    pub fn encode_openmetrics(&self, writer: &mut impl Write) -> fmt::Result {
+    pub fn encode_openmetrics_to_writer(&self, writer: &mut impl Write) -> fmt::Result {
         for group in &self.metrics {
             group.encode_openmetrics(writer, self.prefix.as_deref(), &self.labels)?;
         }
 
         for sub in self.sub_registries.iter() {
-            sub.encode_openmetrics(writer)?;
+            sub.encode_openmetrics_to_writer(writer)?;
         }
         Ok(())
     }
@@ -119,7 +119,7 @@ pub trait MetricsSource: Send + 'static {
 
 impl MetricsSource for Registry {
     fn encode_openmetrics(&self, writer: &mut impl std::fmt::Write) -> Result<(), Error> {
-        self.encode_openmetrics(writer)?;
+        self.encode_openmetrics_to_writer(writer)?;
         write_eof(writer)?;
         Ok(())
     }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -106,12 +106,12 @@ impl Registry {
         Ok(())
     }
 
-    ///
+    /// Returns the current schema version of this registry.
     pub fn schema_version(&self) -> u64 {
         self.schema_version.load(Ordering::Relaxed)
     }
 
-    ///
+    /// Encodes the schema of all registered metrics into the provided schema builder.
     pub fn encode_schema(&self, schema: &mut crate::encoding::Schema) {
         for group in &self.metrics {
             group.encode_schema(schema, self.prefix.as_deref(), &self.labels);
@@ -122,7 +122,7 @@ impl Registry {
         }
     }
 
-    ///
+    /// Encodes the current values of all registered metrics into the provided values builder.
     pub fn encode_values(&self, values: &mut crate::encoding::Values) {
         for group in &self.metrics {
             group.encode_values(values);

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -95,6 +95,8 @@ impl Registry {
     ///
     /// This does not write the terminal `# EOF\n` string to `writer`.
     /// You can use [`encode_openmetrics_eof`] to do that.
+    ///
+    /// [`encode_openmetrics_eof`]: crate::encoding::encode_openmetrics_eof
     pub fn encode_openmetrics_to_writer(&self, writer: &mut impl Write) -> fmt::Result {
         for group in &self.metrics {
             group.encode_openmetrics(writer, self.prefix.as_deref(), &self.labels)?;

--- a/src/service.rs
+++ b/src/service.rs
@@ -2,7 +2,6 @@
 
 use std::{
     net::SocketAddr,
-    ops::Deref,
     sync::{Arc, RwLock},
     time::{Duration, Instant},
 };
@@ -24,13 +23,13 @@ pub type RwLockRegistry = Arc<RwLock<Registry>>;
 impl MetricsSource for RwLockRegistry {
     fn encode_openmetrics(&self, writer: &mut impl std::fmt::Write) -> Result<(), Error> {
         let inner = self.read().expect("poisoned");
-        inner.encode_openmetrics(writer)
+        <Registry as MetricsSource>::encode_openmetrics(&inner, writer)
     }
 }
 
 impl MetricsSource for Arc<Registry> {
     fn encode_openmetrics(&self, writer: &mut impl std::fmt::Write) -> Result<(), Error> {
-        Arc::deref(self).encode_openmetrics(writer)
+        <Registry as MetricsSource>::encode_openmetrics(self, writer)
     }
 }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -2,6 +2,7 @@
 
 use std::{
     net::SocketAddr,
+    ops::Deref,
     sync::{Arc, RwLock},
     time::{Duration, Instant},
 };
@@ -23,13 +24,13 @@ pub type RwLockRegistry = Arc<RwLock<Registry>>;
 impl MetricsSource for RwLockRegistry {
     fn encode_openmetrics(&self, writer: &mut impl std::fmt::Write) -> Result<(), Error> {
         let inner = self.read().expect("poisoned");
-        <Registry as MetricsSource>::encode_openmetrics(&inner, writer)
+        inner.encode_openmetrics(writer)
     }
 }
 
 impl MetricsSource for Arc<Registry> {
     fn encode_openmetrics(&self, writer: &mut impl std::fmt::Write) -> Result<(), Error> {
-        <Registry as MetricsSource>::encode_openmetrics(self, writer)
+        Arc::deref(self).encode_openmetrics(writer)
     }
 }
 

--- a/src/static_core.rs
+++ b/src/static_core.rs
@@ -35,7 +35,7 @@ use std::sync::OnceLock;
 
 use erased_set::ErasedSyncSet;
 
-use crate::{Error, MetricsGroup, NoMetricsSnafu, Registry};
+use crate::{Error, MetricsGroup, MetricsSource, NoMetricsSnafu, Registry};
 
 #[cfg(not(feature = "metrics"))]
 type Registry = ();
@@ -46,10 +46,10 @@ type Registry = ();
 #[derive(Clone, Copy, Debug)]
 pub struct GlobalRegistry;
 
-impl crate::MetricsSource for GlobalRegistry {
+impl MetricsSource for GlobalRegistry {
     fn encode_openmetrics(&self, writer: &mut impl std::fmt::Write) -> Result<(), Error> {
         let core = crate::static_core::Core::get().ok_or(NoMetricsSnafu.build())?;
-        core.registry.encode_openmetrics(writer)
+        <Registry as MetricsSource>::encode_openmetrics(&core.registry, writer)
     }
 }
 

--- a/src/static_core.rs
+++ b/src/static_core.rs
@@ -86,7 +86,7 @@ impl Core {
             #[cfg(feature = "metrics")]
             registry,
         })
-        .map_err(|_| std::io::Error::new(std::io::ErrorKind::Other, "already set"))
+        .map_err(|_| std::io::Error::other("already set"))
     }
 
     /// Returns a reference to the core metrics.

--- a/src/static_core.rs
+++ b/src/static_core.rs
@@ -49,7 +49,7 @@ pub struct GlobalRegistry;
 impl MetricsSource for GlobalRegistry {
     fn encode_openmetrics(&self, writer: &mut impl std::fmt::Write) -> Result<(), Error> {
         let core = crate::static_core::Core::get().ok_or(NoMetricsSnafu.build())?;
-        <Registry as MetricsSource>::encode_openmetrics(&core.registry, writer)
+        core.registry.encode_openmetrics(writer)
     }
 }
 


### PR DESCRIPTION
## Description

Adds an `Encoder` that takes a registry and can emit `Update`s. An `Update` is a serializable struct that has an optional `Schema` and a required `Values`. `Schema` is only sent if the registry was changed after the last send, and contains the name, type, help, prefixes, and labels for all registered metrics. `Values` is just a vec of metric values. So after the schema was sent in the first message, subsequent metrics updates only contain the bare values, so are small.

Also adds a `Decoder` that can ingest the `Update`s and then allows iterating over all metrics (basically zipping the current schema with the current values).


## Breaking Changes
<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->
## Notes & open questions
<!-- Any notes, remarks or open questions you have to make about the PR. -->
## Change checklist
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.