### PR TITLE
feat!: label support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,9 +67,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,9 +935,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,9 +55,9 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byteorder"
@@ -67,15 +67,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cc"
-version = "1.2.54"
+version = "1.2.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
+checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -95,9 +95,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -162,9 +162,9 @@ checksum = "a02a5d186d7bf1cb21f1f95e1a9cfa5c1f2dcd803a47aad454423ceec13525c5"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.8"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "form_urlencoded"
@@ -206,14 +206,13 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "pin-utils",
- "slab",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -351,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
 dependencies = [
  "base64",
  "bytes",
@@ -445,9 +444,9 @@ checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -459,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
 
 [[package]]
 name = "icu_provider"
@@ -507,9 +506,9 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
 dependencies = [
  "memchr",
  "serde",
@@ -526,6 +525,7 @@ dependencies = [
  "iroh-metrics-derive",
  "itoa",
  "n0-error",
+ "parking_lot",
  "portable-atomic",
  "postcard",
  "prometheus-parse",
@@ -557,15 +557,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -573,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "litemap"
@@ -594,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lru-slab"
@@ -612,9 +612,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
  "wasi",
@@ -656,6 +656,29 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -717,9 +740,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
@@ -793,9 +816,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -828,11 +851,20 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -910,7 +942,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.17",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -933,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
  "once_cell",
  "ring",
@@ -947,9 +979,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
 dependencies = [
  "web-time",
  "zeroize",
@@ -957,9 +989,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -974,9 +1006,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "scopeguard"
@@ -1022,15 +1054,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
+ "ryu",
  "serde",
  "serde_core",
- "zmij",
 ]
 
 [[package]]
@@ -1065,9 +1097,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
@@ -1107,9 +1139,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1138,18 +1170,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1183,9 +1215,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
  "bytes",
  "libc",
@@ -1219,9 +1251,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.3"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -1313,9 +1345,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.8"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1355,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1368,12 +1400,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
 dependencies = [
  "cfg-if",
- "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -1382,9 +1413,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1392,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1405,18 +1436,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1434,9 +1465,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.5"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -1693,18 +1724,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.34"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ddd76bcebeed25db614f82bf31a9f4222d3fbba300e6fb6c00afa26cbd4d9d"
+checksum = "4ea879c944afe8a2b25fef16bb4ba234f47c694565e97383b36f3a878219065c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.34"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8187381b52e32220d50b255276aa16a084ec0a9017a0ca2152a1f55c539758d"
+checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1770,9 +1801,3 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "zmij"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,7 +525,6 @@ dependencies = [
  "iroh-metrics-derive",
  "itoa",
  "n0-error",
- "parking_lot",
  "portable-atomic",
  "postcard",
  "prometheus-parse",
@@ -656,29 +655,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -856,15 +832,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,15 +49,15 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byteorder"
@@ -67,15 +67,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -88,10 +88,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "chrono"
-version = "0.4.44"
+name = "cfg_aliases"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -105,26 +111,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
  "thiserror",
-]
-
-[[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -176,9 +162,9 @@ checksum = "a02a5d186d7bf1cb21f1f95e1a9cfa5c1f2dcd803a47aad454423ceec13525c5"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "form_urlencoded"
@@ -191,46 +177,62 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
  "futures-task",
  "pin-project-lite",
- "slab",
+ "pin-utils",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -309,9 +311,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -323,6 +325,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -330,28 +333,31 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.9"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "hyper-util"
-version = "0.1.20"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -368,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.65"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -438,9 +444,9 @@ checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -452,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
 
 [[package]]
 name = "icu_provider"
@@ -494,13 +500,23 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "iroh-metrics"
-version = "0.38.3"
+version = "0.38.2"
 dependencies = [
  "erased_set",
  "http-body-util",
@@ -509,12 +525,11 @@ dependencies = [
  "iroh-metrics-derive",
  "itoa",
  "n0-error",
+ "parking_lot",
  "portable-atomic",
  "postcard",
  "prometheus-parse",
  "reqwest",
- "rustls",
- "rustls-platform-verifier",
  "ryu",
  "serde",
  "tokio",
@@ -542,82 +557,31 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.18"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "jni"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
-dependencies = [
- "cfg-if",
- "combine",
- "jni-macros",
- "jni-sys",
- "log",
- "simd_cesu8",
- "thiserror",
- "walkdir",
- "windows-link",
-]
-
-[[package]]
-name = "jni-macros"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "simd_cesu8",
- "syn",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
-dependencies = [
- "jni-sys-macros",
-]
-
-[[package]]
-name = "jni-sys-macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
-dependencies = [
- "quote",
- "syn",
-]
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
 dependencies = [
- "cfg-if",
- "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lock_api"
@@ -630,21 +594,27 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
  "wasi",
@@ -653,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "n0-error"
-version = "1.0.0-rc.0"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223e946a84aa91644507a6b7865cfebbb9a231ace499041c747ab0fd30408212"
+checksum = "af4782b4baf92d686d161c15460c83d16ebcfd215918763903e9619842665cae"
 dependencies = [
  "n0-error-macros",
  "spez",
@@ -663,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "n0-error-macros"
-version = "1.0.0-rc.0"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565305a21e6b3bf26640ad98f05a0fda12d3ab4315394566b52a7bddb8b34828"
+checksum = "03755949235714b2b307e5ae89dd8c1c2531fb127d9b8b7b4adf9c876cd3ed18"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -683,15 +653,32 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.4"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "openssl-probe"
-version = "0.2.1"
+name = "parking_lot"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -701,9 +688,15 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.17"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "portable-atomic"
@@ -729,18 +722,27 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.106"
+name = "ppv-lite86"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
@@ -758,19 +760,118 @@ dependencies = [
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.45"
+name = "quinn"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "regex"
-version = "1.12.3"
+name = "r-efi"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -780,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -791,15 +892,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
@@ -814,11 +915,12 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -829,6 +931,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -839,11 +942,17 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -856,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
  "once_cell",
  "ring",
@@ -869,58 +978,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-native-certs"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework",
-]
-
-[[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
 [[package]]
-name = "rustls-platform-verifier"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
-dependencies = [
- "core-foundation",
- "core-foundation-sys",
- "jni",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -935,27 +1006,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.23"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "scopeguard"
@@ -964,33 +1017,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "semver"
-version = "1.0.28"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -1024,15 +1054,27 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
+ "ryu",
  "serde",
  "serde_core",
- "zmij",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1042,26 +1084,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "simd_cesu8"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
-dependencies = [
- "rustc_version",
- "simdutf8",
-]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
 name = "slab"
-version = "0.4.12"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -1071,12 +1097,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1113,9 +1139,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1144,18 +1170,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1164,19 +1190,34 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
 ]
 
 [[package]]
-name = "tokio"
-version = "1.52.2"
+name = "tinyvec"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
  "bytes",
  "libc",
@@ -1189,9 +1230,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1210,9 +1251,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.3"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -1225,20 +1266,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.9"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
+ "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
- "url",
 ]
 
 [[package]]
@@ -1292,9 +1333,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.24"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "untrusted"
@@ -1304,9 +1345,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.8"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1319,16 +1360,6 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
 
 [[package]]
 name = "want"
@@ -1346,10 +1377,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.120"
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1360,19 +1400,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
 dependencies = [
+ "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1380,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1393,39 +1436,40 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "webpki-root-certs"
-version = "1.0.7"
+name = "web-time"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
- "rustls-pki-types",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
-name = "winapi-util"
-version = "0.1.11"
+name = "webpki-roots"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
 dependencies = [
- "windows-sys 0.61.2",
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1493,7 +1537,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1511,14 +1564,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1528,10 +1598,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1540,10 +1622,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1552,10 +1646,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1564,22 +1670,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "writeable"
-version = "0.6.3"
+name = "windows_x86_64_msvc"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -1588,9 +1712,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1599,19 +1723,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerofrom"
-version = "0.1.7"
+name = "zerocopy"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "4ea879c944afe8a2b25fef16bb4ba234f47c694565e97383b36f3a878219065c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1627,9 +1771,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -1638,9 +1782,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -1649,17 +1793,11 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "zmij"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,9 +49,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
@@ -88,12 +88,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,6 +105,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
  "thiserror",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -215,24 +229,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "r-efi",
- "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -345,7 +343,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -516,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics"
-version = "0.38.2"
+version = "0.38.3"
 dependencies = [
  "erased_set",
  "http-body-util",
@@ -529,6 +526,8 @@ dependencies = [
  "postcard",
  "prometheus-parse",
  "reqwest",
+ "rustls",
+ "rustls-platform-verifier",
  "ryu",
  "serde",
  "tokio",
@@ -559,6 +558,55 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "js-sys"
@@ -598,12 +646,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "n0-error"
-version = "0.1.3"
+version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4782b4baf92d686d161c15460c83d16ebcfd215918763903e9619842665cae"
+checksum = "223e946a84aa91644507a6b7865cfebbb9a231ace499041c747ab0fd30408212"
 dependencies = [
  "n0-error-macros",
  "spez",
@@ -632,9 +674,9 @@ dependencies = [
 
 [[package]]
 name = "n0-error-macros"
-version = "0.1.3"
+version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03755949235714b2b307e5ae89dd8c1c2531fb127d9b8b7b4adf9c876cd3ed18"
+checksum = "565305a21e6b3bf26640ad98f05a0fda12d3ab4315394566b52a7bddb8b34828"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -655,6 +697,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "percent-encoding"
@@ -706,15 +754,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,102 +775,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
-dependencies = [
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -865,9 +814,9 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
@@ -882,12 +831,11 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -898,7 +846,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -909,17 +856,11 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -945,14 +886,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
 dependencies = [
- "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -978,10 +957,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1033,28 +1053,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "slab"
-version = "0.4.11"
+name = "simd_cesu8"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "smallvec"
@@ -1164,21 +1182,6 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1329,6 +1332,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,15 +1355,6 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
-dependencies = [
- "wit-bindgen",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1421,22 +1425,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-time"
-version = "1.1.0"
+name = "webpki-root-certs"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
- "js-sys",
- "wasm-bindgen",
+ "rustls-pki-types",
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "1.0.4"
+name = "winapi-util"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "rustls-pki-types",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1655,12 +1658,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
-name = "wit-bindgen"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
-
-[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1687,26 +1684,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea879c944afe8a2b25fef16bb4ba234f47c694565e97383b36f3a878219065c"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ unused-async = "warn"
 [dependencies]
 iroh-metrics-derive = { path = "./iroh-metrics-derive", version = "0.4.1" }
 itoa = "1"
-parking_lot = "0.12"
 ryu = "1"
 portable-atomic = { version = "1", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive", "rc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ unused-async = "warn"
 [dependencies]
 iroh-metrics-derive = { path = "./iroh-metrics-derive", version = "0.4.1" }
 itoa = "1"
+parking_lot = "0.12"
 ryu = "1"
 portable-atomic = { version = "1", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive", "rc"] }

--- a/examples/iroh_socket_style.rs
+++ b/examples/iroh_socket_style.rs
@@ -1,0 +1,95 @@
+//! Integration-style demo modelled on iroh's `socket::Metrics`.
+//!
+//! Compares the unlabeled style currently used in iroh (one counter per
+//! transport kind) with the labeled style enabled by this PR. Run with:
+//!
+//!   cargo run --example iroh_socket_style
+
+use std::sync::Arc;
+
+use iroh_metrics::{
+    Counter, EncodeLabelSet, EncodeLabelValue, Family, MetricsGroup, MetricsSource, Registry,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(
+    Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, EncodeLabelSet,
+)]
+struct TransportLabels {
+    transport: Transport,
+    direction: Direction,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Hash,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    EncodeLabelValue,
+)]
+enum Transport {
+    Ipv4,
+    Ipv6,
+    Relay,
+    Custom,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Hash,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    EncodeLabelValue,
+)]
+enum Direction {
+    Send,
+    Recv,
+}
+
+#[derive(Debug, Default, MetricsGroup, Serialize, Deserialize)]
+#[metrics(name = "socket")]
+#[non_exhaustive]
+struct Metrics {
+    /// Total bytes routed.
+    bytes: Family<TransportLabels, Counter>,
+    /// Connections opened (handshake completed).
+    num_conns_opened: Counter,
+    /// Connections closed.
+    num_conns_closed: Counter,
+}
+
+fn main() {
+    let metrics = Arc::new(Metrics::default());
+    let mut registry = Registry::default();
+    registry.register(metrics.clone());
+
+    metrics.num_conns_opened.inc();
+    metrics
+        .bytes
+        .get_or_create(&TransportLabels {
+            transport: Transport::Ipv4,
+            direction: Direction::Send,
+        })
+        .inc_by(1024);
+    metrics
+        .bytes
+        .get_or_create(&TransportLabels {
+            transport: Transport::Relay,
+            direction: Direction::Recv,
+        })
+        .inc_by(2048);
+
+    println!("{}", registry.encode_openmetrics_to_string().unwrap());
+}

--- a/examples/labels.rs
+++ b/examples/labels.rs
@@ -1,0 +1,52 @@
+//! Labeled metrics example.
+//!
+//! Run with: `cargo run --example labels`
+
+use std::sync::Arc;
+
+use iroh_metrics::{
+    Counter, EncodeLabelSet, Family, Histogram, MetricsGroup, MetricsSource, Registry,
+};
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, EncodeLabelSet)]
+struct TransportLabels {
+    protocol: &'static str,
+    #[label(name = "direction")]
+    dir: &'static str,
+}
+
+#[derive(Debug, MetricsGroup)]
+#[metrics(default, name = "example")]
+struct ExampleMetrics {
+    /// Total requests
+    requests: Counter,
+    /// Requests by transport
+    requests_by_transport: Family<TransportLabels, Counter>,
+    /// Latency histogram, by transport
+    #[default(Family::with_constructor(|| Histogram::new(vec![0.1, 0.5, 1.0, 5.0])))]
+    latency: Family<TransportLabels, Histogram>,
+}
+
+fn main() {
+    let metrics = Arc::new(ExampleMetrics::default());
+    let mut registry = Registry::default();
+    registry.register(metrics.clone());
+
+    metrics.requests.inc();
+
+    let send = TransportLabels {
+        protocol: "quic",
+        dir: "send",
+    };
+    let recv = TransportLabels {
+        protocol: "quic",
+        dir: "recv",
+    };
+    metrics.requests_by_transport.get_or_create(&send).inc();
+    metrics.requests_by_transport.get_or_create(&recv).inc();
+    metrics.latency.get_or_create(&send).observe(0.25);
+    metrics.latency.get_or_create(&recv).observe(0.75);
+
+    let output = registry.encode_openmetrics_to_string().unwrap();
+    println!("{output}");
+}

--- a/iroh-metrics-derive/src/lib.rs
+++ b/iroh-metrics-derive/src/lib.rs
@@ -1,4 +1,4 @@
-use heck::ToSnakeCase;
+use heck::{ToKebabCase, ToLowerCamelCase, ToPascalCase, ToShoutySnakeCase, ToSnakeCase};
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{
@@ -38,78 +38,104 @@ pub fn derive_encode_label_set(input: TokenStream) -> TokenStream {
         .into()
 }
 
+/// Derives [`EncodeLabelValue`] for an enum with only unit variants.
+///
+/// Maps each variant to its name (snake_case by default). Use
+/// `#[label(rename_all = "...")]` on the enum or `#[label(name = "...")]`
+/// per-variant to customize.
+#[proc_macro_derive(EncodeLabelValue, attributes(label))]
+pub fn derive_encode_label_value(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    expand_encode_label_value(&input)
+        .unwrap_or_else(Error::into_compile_error)
+        .into()
+}
+
 fn expand_iterable(input: &DeriveInput) -> Result<proc_macro2::TokenStream, Error> {
     let (name, fields) = parse_named_struct(input)?;
 
-    // Separate regular metrics and Family fields
-    let (metric_fields, family_fields): (Vec<_>, Vec<_>) =
-        fields.iter().partition(|f| !is_family_type(&f.ty));
-
-    let metric_count = metric_fields.len();
-    let family_count = family_fields.len();
-
-    // Generate match arms for regular metrics
-    let mut metric_match_arms = quote! {};
-    for (i, field) in metric_fields.iter().enumerate() {
-        let ident = field.ident.as_ref().unwrap();
-        let ident_str = ident.to_string();
+    // Partition into scalars and families. `Family<_, _>` is detected by the
+    // last path segment of the field type, so type aliases require an
+    // explicit `#[metrics(family)]` override.
+    let mut metrics = Vec::new();
+    let mut families = Vec::new();
+    for field in fields.iter() {
         let attr = parse_metrics_attr(&field.attrs)?;
-        let help = attr
-            .help
-            .or_else(|| parse_doc_first_line(&field.attrs))
-            .unwrap_or_else(|| ident_str.clone());
-        metric_match_arms.extend(quote! {
-            #i => Some(::iroh_metrics::MetricItem::new(#ident_str, #help, &self.#ident as &dyn ::iroh_metrics::Metric)),
-        });
+        let info = field_info(field, attr)?;
+        if info.is_family {
+            families.push(info);
+        } else {
+            metrics.push(info);
+        }
     }
 
-    // Generate match arms for Family fields
-    let mut family_match_arms = quote! {};
-    for (i, field) in family_fields.iter().enumerate() {
-        let ident = field.ident.as_ref().unwrap();
-        let ident_str = ident.to_string();
-        let attr = parse_metrics_attr(&field.attrs)?;
-        let help = attr
-            .help
-            .or_else(|| parse_doc_first_line(&field.attrs))
-            .unwrap_or_else(|| ident_str.clone());
-        family_match_arms.extend(quote! {
-            #i => Some(::iroh_metrics::FamilyItem::new(#ident_str, #help, &self.#ident as &dyn ::iroh_metrics::FamilyEncoder)),
-        });
-    }
+    let metric_count = metrics.len();
+    let family_count = families.len();
 
-    let family_impl = if family_count > 0 {
+    let metric_arms = metrics.iter().enumerate().map(|(i, f)| {
+        let (ident, ident_str, help) = (f.ident, &f.ident_str, &f.help);
         quote! {
-            fn family_count(&self) -> usize {
-                #family_count
-            }
+            #i => Some(::iroh_metrics::MetricItem::new(#ident_str, #help, &self.#ident as &dyn ::iroh_metrics::Metric)),
+        }
+    });
+    let family_arms = families.iter().enumerate().map(|(i, f)| {
+        let (ident, ident_str, help) = (f.ident, &f.ident_str, &f.help);
+        quote! {
+            #i => Some(::iroh_metrics::FamilyItem::new(#ident_str, #help, &self.#ident as &dyn ::iroh_metrics::FamilyEncoder)),
+        }
+    });
 
+    let family_impl = (family_count > 0).then(|| {
+        quote! {
+            fn family_count(&self) -> usize { #family_count }
             fn family_ref(&self, n: usize) -> Option<::iroh_metrics::FamilyItem<'_>> {
                 match n {
-                    #family_match_arms
+                    #(#family_arms)*
                     _ => None,
                 }
             }
         }
-    } else {
-        quote! {}
-    };
+    });
 
     Ok(quote! {
         impl ::iroh_metrics::iterable::Iterable for #name {
-            fn field_count(&self) -> usize {
-                #metric_count
-            }
-
+            fn field_count(&self) -> usize { #metric_count }
             fn field_ref(&self, n: usize) -> Option<::iroh_metrics::MetricItem<'_>> {
                 match n {
-                    #metric_match_arms
+                    #(#metric_arms)*
                     _ => None,
                 }
             }
-
             #family_impl
         }
+    })
+}
+
+/// Per-field info pre-computed once for `expand_iterable`.
+struct FieldInfo<'a> {
+    ident: &'a Ident,
+    ident_str: String,
+    /// Help text: explicit `#[metrics(help = "...")]` > first doc line > field name.
+    help: String,
+    is_family: bool,
+}
+
+fn field_info<'a>(field: &'a syn::Field, attr: MetricsAttr) -> Result<FieldInfo<'a>, Error> {
+    let ident = field
+        .ident
+        .as_ref()
+        .ok_or_else(|| Error::new(field.span(), "Only named fields are supported"))?;
+    let ident_str = ident.to_string();
+    let help = attr
+        .help
+        .or_else(|| parse_doc_first_line(&field.attrs))
+        .unwrap_or_else(|| ident_str.clone());
+    let is_family = attr.family || is_family_type(&field.ty);
+    Ok(FieldInfo {
+        ident,
+        ident_str,
+        help,
+        is_family,
     })
 }
 
@@ -217,6 +243,7 @@ fn expand_metrics_group_set(input: &DeriveInput) -> Result<proc_macro2::TokenStr
 
 fn expand_encode_label_set(input: &DeriveInput) -> Result<proc_macro2::TokenStream, Error> {
     let (name, fields) = parse_named_struct(input)?;
+    let struct_attr = parse_label_struct_attr(&input.attrs)?;
 
     let mut label_pairs = vec![];
     for field in fields.iter() {
@@ -231,12 +258,20 @@ fn expand_encode_label_set(input: &DeriveInput) -> Result<proc_macro2::TokenStre
             continue;
         }
 
-        // Use custom name or field name
-        let label_name = attr.name.unwrap_or_else(|| ident.to_string());
+        // Field-level `name = ...` wins; otherwise apply the struct-level
+        // `rename_all` transformation to the field ident.
+        let label_name = match attr.name {
+            Some(n) => n,
+            None => match struct_attr.rename_all {
+                Some(rule) => rule.apply(&ident.to_string()),
+                None => ident.to_string(),
+            },
+        };
 
-        // Generate the label pair based on field type
+        // Borrow the field through `EncodeLabelValue` so string fields
+        // don't allocate on every scrape.
         label_pairs.push(quote! {
-            (#label_name, ::iroh_metrics::LabelValue::from(self.#ident.clone()))
+            (#label_name, ::iroh_metrics::EncodeLabelValue::encode_label_value(&self.#ident))
         });
     }
 
@@ -247,6 +282,109 @@ fn expand_encode_label_set(input: &DeriveInput) -> Result<proc_macro2::TokenStre
             }
         }
     })
+}
+
+fn expand_encode_label_value(input: &DeriveInput) -> Result<proc_macro2::TokenStream, Error> {
+    let name = &input.ident;
+    let Data::Enum(data) = &input.data else {
+        return Err(Error::new(
+            input.span(),
+            "EncodeLabelValue can only be derived for enums with unit variants.",
+        ));
+    };
+    let enum_attr = parse_label_struct_attr(&input.attrs)?;
+    let rule = enum_attr.rename_all.unwrap_or(RenameRule::SnakeCase);
+
+    let mut arms = Vec::new();
+    for variant in &data.variants {
+        if !matches!(variant.fields, Fields::Unit) {
+            return Err(Error::new(
+                variant.span(),
+                "EncodeLabelValue only supports unit variants.",
+            ));
+        }
+        let attr = parse_label_attr(&variant.attrs)?;
+        let ident = &variant.ident;
+        let label = attr.name.unwrap_or_else(|| rule.apply(&ident.to_string()));
+        arms.push(quote! {
+            Self::#ident => ::iroh_metrics::LabelValue::Str(::std::borrow::Cow::Borrowed(#label)),
+        });
+    }
+
+    Ok(quote! {
+        impl ::iroh_metrics::EncodeLabelValue for #name {
+            fn encode_label_value(&self) -> ::iroh_metrics::LabelValue<'_> {
+                match self {
+                    #(#arms)*
+                }
+            }
+        }
+    })
+}
+
+#[derive(Clone, Copy)]
+enum RenameRule {
+    SnakeCase,
+    CamelCase,
+    PascalCase,
+    ScreamingSnakeCase,
+    KebabCase,
+    Lowercase,
+    Uppercase,
+}
+
+impl RenameRule {
+    fn parse(s: &str, span: proc_macro2::Span) -> Result<Self, Error> {
+        match s {
+            "snake_case" => Ok(Self::SnakeCase),
+            "camelCase" => Ok(Self::CamelCase),
+            "PascalCase" => Ok(Self::PascalCase),
+            "SCREAMING_SNAKE_CASE" => Ok(Self::ScreamingSnakeCase),
+            "kebab-case" => Ok(Self::KebabCase),
+            "lowercase" => Ok(Self::Lowercase),
+            "UPPERCASE" => Ok(Self::Uppercase),
+            other => Err(Error::new(
+                span,
+                format!(
+                    "unknown rename_all value `{other}`. Supported: snake_case, camelCase, \
+                     PascalCase, SCREAMING_SNAKE_CASE, kebab-case, lowercase, UPPERCASE.",
+                ),
+            )),
+        }
+    }
+
+    fn apply(self, ident: &str) -> String {
+        match self {
+            Self::SnakeCase => ident.to_snake_case(),
+            Self::CamelCase => ident.to_lower_camel_case(),
+            Self::PascalCase => ident.to_pascal_case(),
+            Self::ScreamingSnakeCase => ident.to_shouty_snake_case(),
+            Self::KebabCase => ident.to_kebab_case(),
+            Self::Lowercase => ident.to_lowercase(),
+            Self::Uppercase => ident.to_uppercase(),
+        }
+    }
+}
+
+#[derive(Default)]
+struct LabelStructAttr {
+    rename_all: Option<RenameRule>,
+}
+
+fn parse_label_struct_attr(attrs: &[Attribute]) -> Result<LabelStructAttr, Error> {
+    let mut out = LabelStructAttr::default();
+    for attr in attrs.iter().filter(|attr| attr.path().is_ident("label")) {
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("rename_all") {
+                let s: LitStr = meta.value()?.parse()?;
+                out.rename_all = Some(RenameRule::parse(&s.value(), s.span())?);
+                Ok(())
+            } else {
+                Err(meta.error("The struct-level `label` attribute supports only `rename_all`."))
+            }
+        })?;
+    }
+    Ok(out)
 }
 
 fn parse_doc_first_line(attrs: &[Attribute]) -> Option<String> {
@@ -268,6 +406,9 @@ struct MetricsAttr {
     name: Option<String>,
     help: Option<String>,
     default: bool,
+    /// `#[metrics(family)]` — force-treat the field as a `Family<_, _>`
+    /// even when the type is hidden behind an alias.
+    family: bool,
 }
 
 #[derive(Default)]
@@ -297,9 +438,12 @@ fn parse_metrics_attr(attrs: &[Attribute]) -> Result<MetricsAttr, syn::Error> {
             } else if meta.path.is_ident("default") {
                 out.default = true;
                 Ok(())
+            } else if meta.path.is_ident("family") {
+                out.family = true;
+                Ok(())
             } else {
                 Err(meta.error(
-                    "The `metrics` attribute supports only `name`, `help` and `default` fields.",
+                    "The `metrics` attribute supports only `name`, `help`, `default`, and `family`.",
                 ))
             }
         })?;

--- a/iroh-metrics-derive/src/lib.rs
+++ b/iroh-metrics-derive/src/lib.rs
@@ -87,8 +87,8 @@ fn expand_iterable(input: &DeriveInput) -> Result<proc_macro2::TokenStream, Erro
 
     let family_impl = (family_count > 0).then(|| {
         quote! {
-            fn family_count(&self) -> usize { #family_count }
-            fn family_ref(&self, n: usize) -> Option<::iroh_metrics::FamilyItem<'_>> {
+            fn family_field_count(&self) -> usize { #family_count }
+            fn family_field_ref(&self, n: usize) -> Option<::iroh_metrics::FamilyItem<'_>> {
                 match n {
                     #(#family_arms)*
                     _ => None,
@@ -99,8 +99,8 @@ fn expand_iterable(input: &DeriveInput) -> Result<proc_macro2::TokenStream, Erro
 
     Ok(quote! {
         impl ::iroh_metrics::iterable::Iterable for #name {
-            fn field_count(&self) -> usize { #metric_count }
-            fn field_ref(&self, n: usize) -> Option<::iroh_metrics::MetricItem<'_>> {
+            fn metric_field_count(&self) -> usize { #metric_count }
+            fn metric_field_ref(&self, n: usize) -> Option<::iroh_metrics::MetricItem<'_>> {
                 match n {
                     #(#metric_arms)*
                     _ => None,

--- a/iroh-metrics-derive/src/lib.rs
+++ b/iroh-metrics-derive/src/lib.rs
@@ -30,6 +30,14 @@ pub fn derive_metrics_group_set(input: TokenStream) -> TokenStream {
     out.into()
 }
 
+#[proc_macro_derive(EncodeLabelSet, attributes(label))]
+pub fn derive_encode_label_set(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    expand_encode_label_set(&input)
+        .unwrap_or_else(Error::into_compile_error)
+        .into()
+}
+
 fn expand_iterable(input: &DeriveInput) -> Result<proc_macro2::TokenStream, Error> {
     let (name, fields) = parse_named_struct(input)?;
 
@@ -147,6 +155,40 @@ fn expand_metrics_group_set(input: &DeriveInput) -> Result<proc_macro2::TokenStr
     })
 }
 
+fn expand_encode_label_set(input: &DeriveInput) -> Result<proc_macro2::TokenStream, Error> {
+    let (name, fields) = parse_named_struct(input)?;
+
+    let mut label_pairs = vec![];
+    for field in fields.iter() {
+        let ident = field
+            .ident
+            .as_ref()
+            .ok_or_else(|| Error::new(field.span(), "Only named fields are supported"))?;
+        let attr = parse_label_attr(&field.attrs)?;
+
+        // Skip fields marked with #[label(skip)]
+        if attr.skip {
+            continue;
+        }
+
+        // Use custom name or field name
+        let label_name = attr.name.unwrap_or_else(|| ident.to_string());
+
+        // Generate the label pair based on field type
+        label_pairs.push(quote! {
+            (#label_name, ::iroh_metrics::LabelValue::from(self.#ident.clone()))
+        });
+    }
+
+    Ok(quote! {
+        impl ::iroh_metrics::EncodeLabelSet for #name {
+            fn encode_label_pairs(&self) -> ::std::vec::Vec<::iroh_metrics::LabelPair<'_>> {
+                ::std::vec![#(#label_pairs),*]
+            }
+        }
+    })
+}
+
 fn parse_doc_first_line(attrs: &[Attribute]) -> Option<String> {
     attrs
         .iter()
@@ -166,6 +208,12 @@ struct MetricsAttr {
     name: Option<String>,
     help: Option<String>,
     default: bool,
+}
+
+#[derive(Default)]
+struct LabelAttr {
+    name: Option<String>,
+    skip: bool,
 }
 
 fn parse_default_attr(attrs: &[Attribute]) -> Result<Option<syn::Expr>, syn::Error> {
@@ -193,6 +241,24 @@ fn parse_metrics_attr(attrs: &[Attribute]) -> Result<MetricsAttr, syn::Error> {
                 Err(meta.error(
                     "The `metrics` attribute supports only `name`, `help` and `default` fields.",
                 ))
+            }
+        })?;
+    }
+    Ok(out)
+}
+
+fn parse_label_attr(attrs: &[Attribute]) -> Result<LabelAttr, syn::Error> {
+    let mut out = LabelAttr::default();
+    for attr in attrs.iter().filter(|attr| attr.path().is_ident("label")) {
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("name") {
+                out.name = Some(parse_lit_str(&meta)?);
+                Ok(())
+            } else if meta.path.is_ident("skip") {
+                out.skip = true;
+                Ok(())
+            } else {
+                Err(meta.error("The `label` attribute supports only `name` and `skip` fields."))
             }
         })?;
     }

--- a/iroh-metrics-derive/src/lib.rs
+++ b/iroh-metrics-derive/src/lib.rs
@@ -2,8 +2,8 @@ use heck::ToSnakeCase;
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{
-    Attribute, Data, DeriveInput, Error, Expr, ExprLit, Fields, Ident, Lit, LitStr,
-    meta::ParseNestedMeta, parse_macro_input, spanned::Spanned,
+    Attribute, Data, DeriveInput, Error, Expr, ExprLit, Fields, GenericArgument, Ident, Lit,
+    LitStr, PathArguments, Type, meta::ParseNestedMeta, parse_macro_input, spanned::Spanned,
 };
 
 #[proc_macro_derive(MetricsGroup, attributes(metrics, default))]
@@ -41,10 +41,16 @@ pub fn derive_encode_label_set(input: TokenStream) -> TokenStream {
 fn expand_iterable(input: &DeriveInput) -> Result<proc_macro2::TokenStream, Error> {
     let (name, fields) = parse_named_struct(input)?;
 
-    let count = fields.len();
+    // Separate regular metrics and Family fields
+    let (metric_fields, family_fields): (Vec<_>, Vec<_>) =
+        fields.iter().partition(|f| !is_family_type(&f.ty));
 
-    let mut match_arms = quote! {};
-    for (i, field) in fields.iter().enumerate() {
+    let metric_count = metric_fields.len();
+    let family_count = family_fields.len();
+
+    // Generate match arms for regular metrics
+    let mut metric_match_arms = quote! {};
+    for (i, field) in metric_fields.iter().enumerate() {
         let ident = field.ident.as_ref().unwrap();
         let ident_str = ident.to_string();
         let attr = parse_metrics_attr(&field.attrs)?;
@@ -52,25 +58,79 @@ fn expand_iterable(input: &DeriveInput) -> Result<proc_macro2::TokenStream, Erro
             .help
             .or_else(|| parse_doc_first_line(&field.attrs))
             .unwrap_or_else(|| ident_str.clone());
-        match_arms.extend(quote! {
+        metric_match_arms.extend(quote! {
             #i => Some(::iroh_metrics::MetricItem::new(#ident_str, #help, &self.#ident as &dyn ::iroh_metrics::Metric)),
         });
     }
 
-    Ok(quote! {
-        impl ::iroh_metrics::iterable::Iterable for #name {
-            fn field_count(&self) -> usize {
-                #count
+    // Generate match arms for Family fields
+    let mut family_match_arms = quote! {};
+    for (i, field) in family_fields.iter().enumerate() {
+        let ident = field.ident.as_ref().unwrap();
+        let ident_str = ident.to_string();
+        let attr = parse_metrics_attr(&field.attrs)?;
+        let help = attr
+            .help
+            .or_else(|| parse_doc_first_line(&field.attrs))
+            .unwrap_or_else(|| ident_str.clone());
+        family_match_arms.extend(quote! {
+            #i => Some(::iroh_metrics::FamilyItem::new(#ident_str, #help, &self.#ident as &dyn ::iroh_metrics::FamilyEncoder)),
+        });
+    }
+
+    let family_impl = if family_count > 0 {
+        quote! {
+            fn family_count(&self) -> usize {
+                #family_count
             }
 
-            fn field_ref(&self, n: usize) -> Option<::iroh_metrics::MetricItem<'_>> {
+            fn family_ref(&self, n: usize) -> Option<::iroh_metrics::FamilyItem<'_>> {
                 match n {
-                    #match_arms
+                    #family_match_arms
                     _ => None,
                 }
             }
         }
+    } else {
+        quote! {}
+    };
+
+    Ok(quote! {
+        impl ::iroh_metrics::iterable::Iterable for #name {
+            fn field_count(&self) -> usize {
+                #metric_count
+            }
+
+            fn field_ref(&self, n: usize) -> Option<::iroh_metrics::MetricItem<'_>> {
+                match n {
+                    #metric_match_arms
+                    _ => None,
+                }
+            }
+
+            #family_impl
+        }
     })
+}
+
+/// Checks if a type is `Family<_, _>`.
+fn is_family_type(ty: &Type) -> bool {
+    if let Type::Path(type_path) = ty {
+        if let Some(segment) = type_path.path.segments.last() {
+            if segment.ident == "Family" {
+                if let PathArguments::AngleBracketed(args) = &segment.arguments {
+                    // Family should have 2 generic arguments
+                    return args
+                        .args
+                        .iter()
+                        .filter(|arg| matches!(arg, GenericArgument::Type(_)))
+                        .count()
+                        == 2;
+                }
+            }
+        }
+    }
+    false
 }
 
 fn expand_metrics(input: &DeriveInput) -> Result<proc_macro2::TokenStream, Error> {

--- a/src/base.rs
+++ b/src/base.rs
@@ -697,8 +697,9 @@ combined_bar_count_total{x="y"} 10
     fn test_family_in_metrics_group() {
         use std::borrow::Cow;
 
-        use crate::{Family, LabelPair, LabelValue, NoLabels};
         use iroh_metrics_derive::MetricsGroup;
+
+        use crate::{Family, LabelPair, LabelValue, NoLabels};
 
         #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Debug)]
         struct TransportLabels {

--- a/src/base.rs
+++ b/src/base.rs
@@ -763,4 +763,130 @@ combined_bar_count_total{x="y"} 10
         assert!(output.contains(r#"transport="relay""#));
         assert!(output.contains("magicsock_latency"));
     }
+
+    // Shared fixtures for the family-related tests below.
+    #[cfg(test)]
+    mod family_tests {
+        use std::sync::{Arc, RwLock};
+
+        use iroh_metrics_derive::MetricsGroup;
+
+        use crate::{
+            Counter, Family, MetricsSource, Registry,
+            encoding::{Decoder, Encoder, Update},
+            iterable::IntoIterable,
+        };
+
+        #[derive(
+            Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Debug, iroh_metrics::EncodeLabelSet,
+        )]
+        struct Proto {
+            proto: String,
+        }
+
+        fn proto(s: &str) -> Proto {
+            Proto { proto: s.into() }
+        }
+
+        #[derive(Debug, Default, MetricsGroup)]
+        #[metrics(name = "net")]
+        struct Net {
+            /// Total bytes
+            bytes: Counter,
+            /// Bytes per protocol
+            bytes_by_proto: Family<Proto, Counter>,
+        }
+
+        fn registered() -> (Arc<Net>, Arc<RwLock<Registry>>) {
+            let metrics = Arc::new(Net::default());
+            let mut registry = Registry::default();
+            registry.register(metrics.clone());
+            (metrics, Arc::new(RwLock::new(registry)))
+        }
+
+        #[test]
+        fn encode_decode_roundtrip_matches_registry() {
+            let (metrics, registry) = registered();
+            metrics.bytes.inc_by(100);
+            metrics
+                .bytes_by_proto
+                .get_or_create(&proto("tcp"))
+                .inc_by(40);
+            metrics
+                .bytes_by_proto
+                .get_or_create(&proto("udp"))
+                .inc_by(60);
+
+            let mut encoder = Encoder::new(registry.clone());
+            let mut decoder = Decoder::default();
+            decoder
+                .import_bytes(&encoder.export_bytes().unwrap())
+                .unwrap();
+
+            let from_decoder = decoder.encode_openmetrics_to_string().unwrap();
+            assert_eq!(
+                from_decoder,
+                registry.encode_openmetrics_to_string().unwrap()
+            );
+            assert!(from_decoder.contains(r#"net_bytes_by_proto_total{proto="tcp"} 40"#));
+            assert!(from_decoder.contains(r#"net_bytes_by_proto_total{proto="udp"} 60"#));
+
+            // Values-only update (no schema change) must still round-trip.
+            metrics
+                .bytes_by_proto
+                .get_or_create(&proto("tcp"))
+                .inc_by(5);
+            decoder
+                .import_bytes(&encoder.export_bytes().unwrap())
+                .unwrap();
+            assert_eq!(
+                decoder.encode_openmetrics_to_string().unwrap(),
+                registry.encode_openmetrics_to_string().unwrap(),
+            );
+        }
+
+        #[test]
+        fn new_label_combo_bumps_schema_version() {
+            let (metrics, registry) = registered();
+            metrics.bytes_by_proto.get_or_create(&proto("tcp")).inc();
+
+            let mut encoder = Encoder::new(registry.clone());
+            // First export publishes schema; second is cached.
+            let first = encoder.export();
+            assert_eq!(first.schema.expect("initial schema").items.len(), 2);
+            assert!(encoder.export().schema.is_none(), "schema must be cached");
+
+            // New label combo invalidates the cached schema.
+            metrics.bytes_by_proto.get_or_create(&proto("udp")).inc();
+            let third = encoder.export();
+            let schema = third.schema.expect("schema re-published after new combo");
+            assert_eq!(schema.items.len(), 3);
+
+            let mut decoder = Decoder::default();
+            decoder.import(Update {
+                schema: Some(schema),
+                values: third.values,
+            });
+            assert_eq!(
+                decoder.encode_openmetrics_to_string().unwrap(),
+                registry.encode_openmetrics_to_string().unwrap(),
+            );
+        }
+
+        #[test]
+        fn metrics_family_attr_overrides_alias_detection() {
+            type Aliased = Family<Proto, Counter>;
+
+            #[derive(Debug, Default, MetricsGroup)]
+            #[metrics(name = "alias")]
+            struct AliasMetrics {
+                #[metrics(family)]
+                via_alias: Aliased,
+            }
+
+            let m = AliasMetrics::default();
+            assert_eq!(IntoIterable::family_iter(&m).count(), 1);
+            assert_eq!(crate::MetricsGroup::iter(&m).count(), 0);
+        }
+    }
 }

--- a/src/base.rs
+++ b/src/base.rs
@@ -692,4 +692,74 @@ combined_bar_count_total{x="y"} 10
             "Decoder should produce identical OpenMetrics output to registry for histograms"
         );
     }
+
+    #[test]
+    fn test_family_in_metrics_group() {
+        use std::borrow::Cow;
+
+        use crate::{Family, LabelPair, LabelValue, NoLabels};
+        use iroh_metrics_derive::MetricsGroup;
+
+        #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Debug)]
+        struct TransportLabels {
+            transport: String,
+        }
+
+        impl crate::EncodeLabelSet for TransportLabels {
+            fn encode_label_pairs(&self) -> Vec<LabelPair<'_>> {
+                vec![("transport", LabelValue::Str(Cow::Borrowed(&self.transport)))]
+            }
+        }
+
+        #[derive(Debug, MetricsGroup)]
+        #[metrics(default, name = "magicsock")]
+        struct Metrics {
+            /// Total bytes sent
+            total_bytes: Counter,
+            /// Bytes by transport
+            bytes_by_transport: Family<TransportLabels, Counter>,
+            /// Latency histogram
+            #[default(Family::with_constructor(|| crate::Histogram::new(vec![0.1, 1.0, 10.0])))]
+            latency: Family<NoLabels, crate::Histogram>,
+        }
+
+        let metrics = Metrics::default();
+
+        // Regular metric
+        metrics.total_bytes.inc_by(100);
+
+        // Family metrics
+        metrics
+            .bytes_by_transport
+            .get_or_create(&TransportLabels {
+                transport: "ipv4".into(),
+            })
+            .inc_by(50);
+        metrics
+            .bytes_by_transport
+            .get_or_create(&TransportLabels {
+                transport: "relay".into(),
+            })
+            .inc_by(30);
+        metrics.latency.get_or_create(&NoLabels).observe(0.5);
+
+        // Check regular metrics iteration
+        let regular_count = metrics.iter().count();
+        assert_eq!(regular_count, 1, "Should have 1 regular metric");
+
+        // Check family iteration
+        let family_count = IntoIterable::family_iter(&metrics).count();
+        assert_eq!(family_count, 2, "Should have 2 family metrics");
+
+        // Register and encode
+        let mut registry = Registry::default();
+        registry.register(Arc::new(metrics));
+
+        let output = registry.encode_openmetrics_to_string().unwrap();
+        assert!(output.contains("magicsock_total_bytes_total 100"));
+        assert!(output.contains("magicsock_bytes_by_transport"));
+        assert!(output.contains(r#"transport="ipv4""#));
+        assert!(output.contains(r#"transport="relay""#));
+        assert!(output.contains("magicsock_latency"));
+    }
 }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -11,9 +11,36 @@ use std::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    MetricItem, MetricType, MetricValue, MetricsGroup, MetricsSource, RwLockRegistry,
+    LabelValue, MetricItem, MetricType, MetricValue, MetricsGroup, MetricsSource, RwLockRegistry,
     iterable::IntoIterable,
 };
+
+/// Writes a label value directly to the writer.
+///
+/// Blanket-implemented for any `AsRef<str>` so existing callers using `&str`,
+/// `String`, or `Cow<str>` continue to work. The dedicated impl for
+/// [`LabelValue`] avoids allocating an intermediate `String` for integer and
+/// boolean variants.
+pub(crate) trait WriteLabelValue {
+    fn write_label_value<W: Write + ?Sized>(&self, w: &mut W) -> fmt::Result;
+}
+
+impl<T: AsRef<str> + ?Sized> WriteLabelValue for T {
+    fn write_label_value<W: Write + ?Sized>(&self, w: &mut W) -> fmt::Result {
+        w.write_str(self.as_ref())
+    }
+}
+
+impl WriteLabelValue for LabelValue<'_> {
+    fn write_label_value<W: Write + ?Sized>(&self, w: &mut W) -> fmt::Result {
+        match self {
+            LabelValue::Str(s) => w.write_str(s),
+            LabelValue::Int(v) => w.write_str(itoa::Buffer::new().format(*v)),
+            LabelValue::Uint(v) => w.write_str(itoa::Buffer::new().format(*v)),
+            LabelValue::Bool(v) => w.write_str(if *v { "true" } else { "false" }),
+        }
+    }
+}
 
 pub(crate) fn encode_eof(writer: &mut impl Write) -> fmt::Result {
     writer.write_str("# EOF\n")
@@ -36,9 +63,9 @@ pub(crate) fn encode_metric_value<W, K1, V1, K2, V2>(
 where
     W: Write + ?Sized,
     K1: AsRef<str>,
-    V1: AsRef<str>,
+    V1: WriteLabelValue,
     K2: AsRef<str>,
-    V2: AsRef<str>,
+    V2: WriteLabelValue,
 {
     match value {
         MetricValue::Counter(v) => {
@@ -97,9 +124,9 @@ fn encode_labels<W, K1, V1, K2, V2>(
 where
     W: Write + ?Sized,
     K1: AsRef<str>,
-    V1: AsRef<str>,
+    V1: WriteLabelValue,
     K2: AsRef<str>,
-    V2: AsRef<str>,
+    V2: WriteLabelValue,
 {
     if labels.is_empty() && extra_labels.is_empty() && le.is_none() {
         return Ok(());
@@ -112,7 +139,10 @@ where
         if !first {
             w.write_char(',')?;
         }
-        write!(w, "{}=\"{}\"", k.as_ref(), v.as_ref())?;
+        w.write_str(k.as_ref())?;
+        w.write_str("=\"")?;
+        v.write_label_value(w)?;
+        w.write_char('"')?;
         first = false;
     }
 
@@ -120,7 +150,10 @@ where
         if !first {
             w.write_char(',')?;
         }
-        write!(w, "{}=\"{}\"", k.as_ref(), v.as_ref())?;
+        w.write_str(k.as_ref())?;
+        w.write_str("=\"")?;
+        v.write_label_value(w)?;
+        w.write_char('"')?;
         first = false;
     }
 
@@ -173,11 +206,31 @@ impl ItemSchema {
         K: AsRef<str>,
         V: AsRef<str>,
     {
+        Self::from_label_iter(
+            name,
+            prefixes,
+            labels.iter().map(|(k, v)| (k.as_ref(), v.as_ref())),
+            metric_type,
+        )
+    }
+
+    /// Creates a new schema item from a label iterator (avoids materializing a slice).
+    pub fn from_label_iter<'a, I, K, V>(
+        name: &str,
+        prefixes: &[impl AsRef<str>],
+        labels: I,
+        metric_type: MetricType,
+    ) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<str> + 'a,
+        V: AsRef<str> + 'a,
+    {
         Self {
             name: name.to_string(),
             prefixes: prefixes.iter().map(|s| s.as_ref().to_string()).collect(),
             labels: labels
-                .iter()
+                .into_iter()
                 .map(|(k, v)| (k.as_ref().to_string(), v.as_ref().to_string()))
                 .collect(),
             r#type: metric_type,
@@ -303,6 +356,10 @@ impl Item<'_> {
     /// Encodes this metric item to OpenMetrics format.
     ///
     /// Writes the metric in OpenMetrics text format to the provided writer.
+    /// Always includes `# HELP` and `# TYPE` headers — if you are iterating
+    /// items yourself across a family of metrics, prefer
+    /// [`MetricsSource::encode_openmetrics`](crate::MetricsSource::encode_openmetrics)
+    /// on the [`Decoder`], which deduplicates headers across same-named items.
     pub fn encode_openmetrics(
         &self,
         writer: &mut impl std::fmt::Write,
@@ -317,6 +374,45 @@ impl Item<'_> {
                 .map(|(a, b)| (a.as_str(), b.as_str())),
         )?;
         Ok(())
+    }
+
+    /// Writes only the `# HELP` and `# TYPE` headers for this item.
+    pub(crate) fn encode_openmetrics_header(
+        &self,
+        writer: &mut impl std::fmt::Write,
+    ) -> fmt::Result {
+        writer.write_str("# HELP ")?;
+        encode_prefix_name(writer, &self.schema.prefixes, &self.schema.name)?;
+        writer.write_str(" ")?;
+        encode_help_text(writer, self.help.map(|x| x.as_str()).unwrap_or_default())?;
+
+        writer.write_str("# TYPE ")?;
+        encode_prefix_name(writer, &self.schema.prefixes, &self.schema.name)?;
+        writer.write_str(" ")?;
+        writer.write_str(self.schema.r#type.as_str())?;
+        writer.write_str("\n")
+    }
+
+    /// Writes only the value line(s) for this item, without `# HELP`/`# TYPE`.
+    pub(crate) fn encode_openmetrics_value(
+        &self,
+        writer: &mut impl std::fmt::Write,
+    ) -> fmt::Result {
+        let labels: Vec<_> = self
+            .schema
+            .labels
+            .iter()
+            .map(|(a, b)| (a.as_str(), b.as_str()))
+            .collect();
+        let empty: &[(&str, &str)] = &[];
+        encode_metric_value(
+            writer,
+            &self.schema.name,
+            &self.schema.prefixes,
+            &labels,
+            empty,
+            self.value,
+        )
     }
 }
 
@@ -395,8 +491,18 @@ impl<'a> Iterator for DecoderIter<'a> {
 
 impl MetricsSource for Decoder {
     fn encode_openmetrics(&self, writer: &mut impl std::fmt::Write) -> Result<(), crate::Error> {
+        // Family entries share name and type but appear as separate items in
+        // the schema. Emit `# HELP` / `# TYPE` only when the prefixed name
+        // changes between consecutive items, matching what the registry path
+        // produces.
+        let mut prev_key: Option<(Vec<String>, String)> = None;
         for item in self.iter() {
-            item.encode_openmetrics(writer)?;
+            let key = (item.schema.prefixes.clone(), item.schema.name.clone());
+            if prev_key.as_ref() != Some(&key) {
+                item.encode_openmetrics_header(writer)?;
+                prev_key = Some(key);
+            }
+            item.encode_openmetrics_value(writer)?;
         }
         encode_eof(writer)?;
         Ok(())
@@ -564,8 +670,7 @@ pub(crate) trait EncodableMetric {
         writer.write_str("# HELP ")?;
         encode_prefix_name(writer, prefixes, self.name())?;
         writer.write_str(" ")?;
-        writer.write_str(self.help())?;
-        writer.write_str(".\n")?;
+        encode_help_text(writer, self.help())?;
 
         writer.write_str("# TYPE ")?;
         encode_prefix_name(writer, prefixes, self.name())?;
@@ -641,4 +746,14 @@ pub(crate) fn encode_prefix_name(
     }
     writer.write_str(name)?;
     Ok(())
+}
+
+/// Writes `help` followed by `".\n"` — but skips the period if `help`
+/// already ends with `.`, `?` or `!`.
+pub(crate) fn encode_help_text(writer: &mut (impl Write + ?Sized), help: &str) -> fmt::Result {
+    writer.write_str(help)?;
+    if !matches!(help.chars().last(), Some('.') | Some('?') | Some('!')) {
+        writer.write_str(".")?;
+    }
+    writer.write_str("\n")
 }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -15,66 +15,43 @@ use crate::{
     iterable::IntoIterable,
 };
 
-pub(crate) fn write_eof(writer: &mut impl Write) -> fmt::Result {
+pub(crate) fn encode_eof(writer: &mut impl Write) -> fmt::Result {
     writer.write_str("# EOF\n")
 }
 
-/// Adds a schema item to the schema.
-pub(crate) fn encode_schema_item<K, V>(
-    schema: &mut Schema,
-    name: &str,
-    help: &str,
-    prefixes: &[impl AsRef<str>],
-    labels: &[(K, V)],
-    metric_type: MetricType,
-) where
-    K: AsRef<str>,
-    V: AsRef<str>,
-{
-    schema.items.push(ItemSchema {
-        name: name.to_string(),
-        prefixes: prefixes.iter().map(|s| s.as_ref().to_string()).collect(),
-        labels: labels
-            .iter()
-            .map(|(k, v)| (k.as_ref().to_string(), v.as_ref().to_string()))
-            .collect(),
-        r#type: metric_type,
-    });
-    if let Some(h) = schema.help.as_mut() {
-        h.push(help.to_string());
-    }
-}
-
-/// Adds a metric value to the values collection.
-pub(crate) fn encode_value_item(values: &mut Values, value: MetricValue) {
-    values.items.push(value);
-}
-
 /// Encodes a metric value (without HELP/TYPE headers) in OpenMetrics format.
-pub(crate) fn encode_metric_value<W, K, V>(
+///
+/// The following suffixes are appended to the metric name per the OpenMetrics spec:
+/// - Counter: `_total` (e.g. `my_counter_total`)
+/// - Gauge: no suffix
+/// - Histogram: `_bucket` (with `le` label), `_sum`, `_count`
+pub(crate) fn encode_metric_value<W, K1, V1, K2, V2>(
     writer: &mut W,
     name: &str,
     prefixes: &[impl AsRef<str>],
-    labels: &[(K, V)],
+    labels: &[(K1, V1)],
+    extra_labels: &[(K2, V2)],
     value: &MetricValue,
 ) -> fmt::Result
 where
     W: Write + ?Sized,
-    K: AsRef<str>,
-    V: AsRef<str>,
+    K1: AsRef<str>,
+    V1: AsRef<str>,
+    K2: AsRef<str>,
+    V2: AsRef<str>,
 {
     match value {
         MetricValue::Counter(v) => {
-            write_prefix_name(writer, prefixes, name)?;
+            encode_prefix_name(writer, prefixes, name)?;
             writer.write_str("_total")?;
-            write_labels_slice(writer, labels, None)?;
+            encode_labels(writer, labels, extra_labels, None)?;
             writer.write_char(' ')?;
             encode_u64(writer, *v)?;
             writer.write_char('\n')?;
         }
         MetricValue::Gauge(v) => {
-            write_prefix_name(writer, prefixes, name)?;
-            write_labels_slice(writer, labels, None)?;
+            encode_prefix_name(writer, prefixes, name)?;
+            encode_labels(writer, labels, extra_labels, None)?;
             writer.write_char(' ')?;
             encode_i64(writer, *v)?;
             writer.write_char('\n')?;
@@ -85,24 +62,24 @@ where
             count,
         } => {
             for (le, cnt) in buckets {
-                write_prefix_name(writer, prefixes, name)?;
+                encode_prefix_name(writer, prefixes, name)?;
                 writer.write_str("_bucket")?;
-                write_labels_slice(writer, labels, Some(*le))?;
+                encode_labels(writer, labels, extra_labels, Some(*le))?;
                 writer.write_char(' ')?;
                 encode_u64(writer, *cnt)?;
                 writer.write_char('\n')?;
             }
 
-            write_prefix_name(writer, prefixes, name)?;
+            encode_prefix_name(writer, prefixes, name)?;
             writer.write_str("_sum")?;
-            write_labels_slice(writer, labels, None)?;
+            encode_labels(writer, labels, extra_labels, None)?;
             writer.write_char(' ')?;
             encode_f64(writer, *sum)?;
             writer.write_char('\n')?;
 
-            write_prefix_name(writer, prefixes, name)?;
+            encode_prefix_name(writer, prefixes, name)?;
             writer.write_str("_count")?;
-            write_labels_slice(writer, labels, None)?;
+            encode_labels(writer, labels, extra_labels, None)?;
             writer.write_char(' ')?;
             encode_u64(writer, *count)?;
             writer.write_char('\n')?;
@@ -111,13 +88,20 @@ where
     Ok(())
 }
 
-fn write_labels_slice<W, K, V>(w: &mut W, labels: &[(K, V)], le: Option<f64>) -> fmt::Result
+fn encode_labels<W, K1, V1, K2, V2>(
+    w: &mut W,
+    labels: &[(K1, V1)],
+    extra_labels: &[(K2, V2)],
+    le: Option<f64>,
+) -> fmt::Result
 where
     W: Write + ?Sized,
-    K: AsRef<str>,
-    V: AsRef<str>,
+    K1: AsRef<str>,
+    V1: AsRef<str>,
+    K2: AsRef<str>,
+    V2: AsRef<str>,
 {
-    if labels.is_empty() && le.is_none() {
+    if labels.is_empty() && extra_labels.is_empty() && le.is_none() {
         return Ok(());
     }
 
@@ -125,6 +109,14 @@ where
     let mut first = true;
 
     for (k, v) in labels {
+        if !first {
+            w.write_char(',')?;
+        }
+        write!(w, "{}=\"{}\"", k.as_ref(), v.as_ref())?;
+        first = false;
+    }
+
+    for (k, v) in extra_labels {
         if !first {
             w.write_char(',')?;
         }
@@ -150,7 +142,7 @@ where
 ///
 /// This is the expected last characters of an OpenMetrics string.
 pub fn encode_openmetrics_eof(writer: &mut impl Write) -> fmt::Result {
-    write_eof(writer)
+    encode_eof(writer)
 }
 
 /// Schema information for a single metric item.
@@ -170,6 +162,28 @@ pub struct ItemSchema {
 }
 
 impl ItemSchema {
+    /// Creates a new schema item from the given metadata.
+    pub fn new<K, V>(
+        name: &str,
+        prefixes: &[impl AsRef<str>],
+        labels: &[(K, V)],
+        metric_type: MetricType,
+    ) -> Self
+    where
+        K: AsRef<str>,
+        V: AsRef<str>,
+    {
+        Self {
+            name: name.to_string(),
+            prefixes: prefixes.iter().map(|s| s.as_ref().to_string()).collect(),
+            labels: labels
+                .iter()
+                .map(|(k, v)| (k.as_ref().to_string(), v.as_ref().to_string()))
+                .collect(),
+            r#type: metric_type,
+        }
+    }
+
     /// Returns the name prefixed with all prefixes.
     pub fn prefixed_name(&self) -> String {
         let mut out = String::new();
@@ -194,6 +208,14 @@ pub struct Schema {
 }
 
 impl Schema {
+    /// Pushes a schema item and its help text.
+    pub fn push(&mut self, item: ItemSchema, help: &str) {
+        self.items.push(item);
+        if let Some(h) = self.help.as_mut() {
+            h.push(help.to_string());
+        }
+    }
+
     /// Creates a new [`Schema`] that does not track help text.
     pub fn new_without_help() -> Self {
         Self {
@@ -376,7 +398,7 @@ impl MetricsSource for Decoder {
         for item in self.iter() {
             item.encode_openmetrics(writer)?;
         }
-        write_eof(writer)?;
+        encode_eof(writer)?;
         Ok(())
     }
 }
@@ -540,19 +562,27 @@ pub(crate) trait EncodableMetric {
         labels: impl Iterator<Item = (&'a str, &'a str)> + 'a,
     ) -> fmt::Result {
         writer.write_str("# HELP ")?;
-        write_prefix_name(writer, prefixes, self.name())?;
+        encode_prefix_name(writer, prefixes, self.name())?;
         writer.write_str(" ")?;
         writer.write_str(self.help())?;
         writer.write_str(".\n")?;
 
         writer.write_str("# TYPE ")?;
-        write_prefix_name(writer, prefixes, self.name())?;
+        encode_prefix_name(writer, prefixes, self.name())?;
         writer.write_str(" ")?;
         writer.write_str(self.r#type().as_str())?;
         writer.write_str("\n")?;
 
         let labels_vec: Vec<_> = labels.collect();
-        encode_metric_value(writer, self.name(), prefixes, &labels_vec, &self.value())?;
+        let empty: &[(&str, &str)] = &[];
+        encode_metric_value(
+            writer,
+            self.name(),
+            prefixes,
+            &labels_vec,
+            empty,
+            &self.value(),
+        )?;
         Ok(())
     }
 }
@@ -565,18 +595,14 @@ impl MetricItem<'_> {
         labels: impl Iterator<Item = (&'a str, &'a str)> + 'a,
     ) {
         let labels_vec: Vec<_> = labels.collect();
-        encode_schema_item(
-            schema,
-            self.name(),
+        schema.push(
+            ItemSchema::new(self.name(), prefixes, &labels_vec, self.r#type()),
             self.help(),
-            prefixes,
-            &labels_vec,
-            self.r#type(),
         );
     }
 
     fn encode_value(&self, values: &mut Values) {
-        encode_value_item(values, self.value());
+        values.items.push(self.value());
     }
 
     pub(crate) fn encode_openmetrics<'a>(
@@ -604,7 +630,7 @@ pub(crate) fn encode_f64(writer: &mut (impl Write + ?Sized), v: f64) -> fmt::Res
     Ok(())
 }
 
-pub(crate) fn write_prefix_name(
+pub(crate) fn encode_prefix_name(
     writer: &mut (impl Write + ?Sized),
     prefixes: &[impl AsRef<str>],
     name: &str,

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -15,24 +15,24 @@ use crate::{
     iterable::IntoIterable,
 };
 
-/// Writes a label value directly to the writer.
+/// Encodes a label value directly into the writer.
 ///
 /// Blanket-implemented for any `AsRef<str>` so existing callers using `&str`,
 /// `String`, or `Cow<str>` continue to work. The dedicated impl for
 /// [`LabelValue`] avoids allocating an intermediate `String` for integer and
 /// boolean variants.
-pub(crate) trait WriteLabelValue {
-    fn write_label_value<W: Write + ?Sized>(&self, w: &mut W) -> fmt::Result;
+pub(crate) trait EncodeLabelTo {
+    fn encode_to<W: Write + ?Sized>(&self, w: &mut W) -> fmt::Result;
 }
 
-impl<T: AsRef<str> + ?Sized> WriteLabelValue for T {
-    fn write_label_value<W: Write + ?Sized>(&self, w: &mut W) -> fmt::Result {
+impl<T: AsRef<str> + ?Sized> EncodeLabelTo for T {
+    fn encode_to<W: Write + ?Sized>(&self, w: &mut W) -> fmt::Result {
         w.write_str(self.as_ref())
     }
 }
 
-impl WriteLabelValue for LabelValue<'_> {
-    fn write_label_value<W: Write + ?Sized>(&self, w: &mut W) -> fmt::Result {
+impl EncodeLabelTo for LabelValue<'_> {
+    fn encode_to<W: Write + ?Sized>(&self, w: &mut W) -> fmt::Result {
         match self {
             LabelValue::Str(s) => w.write_str(s),
             LabelValue::Int(v) => w.write_str(itoa::Buffer::new().format(*v)),
@@ -63,9 +63,9 @@ pub(crate) fn encode_metric_value<W, K1, V1, K2, V2>(
 where
     W: Write + ?Sized,
     K1: AsRef<str>,
-    V1: WriteLabelValue,
+    V1: EncodeLabelTo,
     K2: AsRef<str>,
-    V2: WriteLabelValue,
+    V2: EncodeLabelTo,
 {
     match value {
         MetricValue::Counter(v) => {
@@ -124,9 +124,9 @@ fn encode_labels<W, K1, V1, K2, V2>(
 where
     W: Write + ?Sized,
     K1: AsRef<str>,
-    V1: WriteLabelValue,
+    V1: EncodeLabelTo,
     K2: AsRef<str>,
-    V2: WriteLabelValue,
+    V2: EncodeLabelTo,
 {
     if labels.is_empty() && extra_labels.is_empty() && le.is_none() {
         return Ok(());
@@ -141,7 +141,7 @@ where
         }
         w.write_str(k.as_ref())?;
         w.write_str("=\"")?;
-        v.write_label_value(w)?;
+        v.encode_to(w)?;
         w.write_char('"')?;
         first = false;
     }
@@ -152,7 +152,7 @@ where
         }
         w.write_str(k.as_ref())?;
         w.write_str("=\"")?;
-        v.write_label_value(w)?;
+        v.encode_to(w)?;
         w.write_char('"')?;
         first = false;
     }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -16,63 +16,129 @@ pub(crate) fn write_eof(writer: &mut impl Write) -> fmt::Result {
     writer.write_str("# EOF\n")
 }
 
-/// Helper function to encode histogram data in OpenMetrics format.
-fn encode_histogram_data<'a>(
+/// Adds a schema item to the schema.
+pub(crate) fn encode_schema_item<K, V>(
+    schema: &mut Schema,
+    name: &str,
+    help: &str,
+    prefixes: &[impl AsRef<str>],
+    labels: &[(K, V)],
+    metric_type: MetricType,
+) where
+    K: AsRef<str>,
+    V: AsRef<str>,
+{
+    schema.items.push(ItemSchema {
+        name: name.to_string(),
+        prefixes: prefixes.iter().map(|s| s.as_ref().to_string()).collect(),
+        labels: labels
+            .iter()
+            .map(|(k, v)| (k.as_ref().to_string(), v.as_ref().to_string()))
+            .collect(),
+        r#type: metric_type,
+    });
+    if let Some(h) = schema.help.as_mut() {
+        h.push(help.to_string());
+    }
+}
+
+/// Adds a metric value to the values collection.
+pub(crate) fn encode_value_item(values: &mut Values, value: MetricValue) {
+    values.items.push(value);
+}
+
+/// Encodes a metric value (without HELP/TYPE headers) in OpenMetrics format.
+pub(crate) fn encode_metric_value<K, V>(
     writer: &mut impl Write,
     name: &str,
     prefixes: &[impl AsRef<str>],
-    labels: &[(&'a str, &'a str)],
-    histogram_data: &HistogramData,
-) -> fmt::Result {
-    // Write buckets
-    for (upper_bound, count) in &histogram_data.buckets {
-        write_prefix_name(writer, prefixes, name)?;
-        writer.write_str("_bucket")?;
-        writer.write_char('{')?;
-        for (i, (key, value)) in labels.iter().enumerate() {
-            if i > 0 {
-                writer.write_char(',')?;
+    labels: &[(K, V)],
+    value: &MetricValue,
+) -> fmt::Result
+where
+    K: AsRef<str>,
+    V: AsRef<str>,
+{
+    match value {
+        MetricValue::Counter(v) => {
+            write_prefix_name(writer, prefixes, name)?;
+            writer.write_str("_total")?;
+            write_labels_slice(writer, labels, None)?;
+            writer.write_char(' ')?;
+            encode_u64(writer, *v)?;
+            writer.write_char('\n')?;
+        }
+        MetricValue::Gauge(v) => {
+            write_prefix_name(writer, prefixes, name)?;
+            write_labels_slice(writer, labels, None)?;
+            writer.write_char(' ')?;
+            encode_i64(writer, *v)?;
+            writer.write_char('\n')?;
+        }
+        MetricValue::Histogram {
+            buckets,
+            sum,
+            count,
+        } => {
+            for (le, cnt) in buckets {
+                write_prefix_name(writer, prefixes, name)?;
+                writer.write_str("_bucket")?;
+                write_labels_slice(writer, labels, Some(*le))?;
+                writer.write_char(' ')?;
+                encode_u64(writer, *cnt)?;
+                writer.write_char('\n')?;
             }
-            writer.write_str(key)?;
-            writer.write_str("=\"")?;
-            writer.write_str(value)?;
-            writer.write_char('"')?;
-        }
-        if !labels.is_empty() {
-            writer.write_char(',')?;
-        }
-        writer.write_str("le=\"")?;
-        if *upper_bound == f64::INFINITY {
-            writer.write_str("+Inf")?;
-        } else {
-            writer.write_str(ryu::Buffer::new().format(*upper_bound))?;
-        }
-        writer.write_str("\"} ")?;
-        encode_u64(writer, *count)?;
-        writer.write_str("\n")?;
-    }
 
-    // Write sum
-    write_prefix_name(writer, prefixes, name)?;
-    writer.write_str("_sum")?;
-    if !labels.is_empty() {
-        write_labels(writer, labels.iter().copied())?;
-    }
-    writer.write_char(' ')?;
-    encode_f64(writer, histogram_data.sum)?;
-    writer.write_str("\n")?;
+            write_prefix_name(writer, prefixes, name)?;
+            writer.write_str("_sum")?;
+            write_labels_slice(writer, labels, None)?;
+            writer.write_char(' ')?;
+            encode_f64(writer, *sum)?;
+            writer.write_char('\n')?;
 
-    // Write count
-    write_prefix_name(writer, prefixes, name)?;
-    writer.write_str("_count")?;
-    if !labels.is_empty() {
-        write_labels(writer, labels.iter().copied())?;
+            write_prefix_name(writer, prefixes, name)?;
+            writer.write_str("_count")?;
+            write_labels_slice(writer, labels, None)?;
+            writer.write_char(' ')?;
+            encode_u64(writer, *count)?;
+            writer.write_char('\n')?;
+        }
     }
-    writer.write_char(' ')?;
-    encode_u64(writer, histogram_data.count)?;
-    writer.write_str("\n")?;
-
     Ok(())
+}
+
+fn write_labels_slice<K, V>(w: &mut impl Write, labels: &[(K, V)], le: Option<f64>) -> fmt::Result
+where
+    K: AsRef<str>,
+    V: AsRef<str>,
+{
+    if labels.is_empty() && le.is_none() {
+        return Ok(());
+    }
+
+    w.write_char('{')?;
+    let mut first = true;
+
+    for (k, v) in labels {
+        if !first {
+            w.write_char(',')?;
+        }
+        write!(w, "{}=\"{}\"", k.as_ref(), v.as_ref())?;
+        first = false;
+    }
+
+    if let Some(le) = le {
+        if !first {
+            w.write_char(',')?;
+        }
+        if le.is_infinite() {
+            w.write_str("le=\"+Inf\"")?;
+        } else {
+            write!(w, "le=\"{}\"", ryu::Buffer::new().format(le))?;
+        }
+    }
+
+    w.write_char('}')
 }
 
 /// Writes `# EOF\n` to `writer`.
@@ -471,36 +537,8 @@ pub(crate) trait EncodableMetric {
         writer.write_str(self.r#type().as_str())?;
         writer.write_str("\n")?;
 
-        match self.value() {
-            MetricValue::Histogram {
-                buckets,
-                sum,
-                count,
-            } => {
-                let labels_vec: Vec<_> = labels.collect();
-                let histogram_data = HistogramData {
-                    buckets,
-                    sum,
-                    count,
-                };
-                encode_histogram_data(writer, self.name(), prefixes, &labels_vec, &histogram_data)?;
-            }
-            MetricValue::Counter(value) => {
-                write_prefix_name(writer, prefixes, self.name())?;
-                writer.write_str("_total")?;
-                write_labels(writer, labels)?;
-                writer.write_char(' ')?;
-                encode_u64(writer, value)?;
-                writer.write_str("\n")?;
-            }
-            MetricValue::Gauge(value) => {
-                write_prefix_name(writer, prefixes, self.name())?;
-                write_labels(writer, labels)?;
-                writer.write_char(' ')?;
-                encode_i64(writer, value)?;
-                writer.write_str("\n")?;
-            }
-        }
+        let labels_vec: Vec<_> = labels.collect();
+        encode_metric_value(writer, self.name(), prefixes, &labels_vec, &self.value())?;
         Ok(())
     }
 }
@@ -512,22 +550,19 @@ impl MetricItem<'_> {
         prefixes: &[&str],
         labels: impl Iterator<Item = (&'a str, &'a str)> + 'a,
     ) {
-        let item = crate::encoding::ItemSchema {
-            name: self.name().to_string(),
-            prefixes: prefixes.iter().map(|s| s.to_string()).collect(),
-            labels: labels
-                .map(|(k, v)| (k.to_string(), v.to_string()))
-                .collect(),
-            r#type: self.r#type(),
-        };
-        schema.items.push(item);
-        if let Some(help) = schema.help.as_mut() {
-            help.push(self.help().to_string());
-        }
+        let labels_vec: Vec<_> = labels.collect();
+        encode_schema_item(
+            schema,
+            self.name(),
+            self.help(),
+            prefixes,
+            &labels_vec,
+            self.r#type(),
+        );
     }
 
     fn encode_value(&self, values: &mut Values) {
-        values.items.push(self.value());
+        encode_value_item(values, self.value());
     }
 
     pub(crate) fn encode_openmetrics<'a>(
@@ -540,47 +575,22 @@ impl MetricItem<'_> {
     }
 }
 
-fn write_labels<'a>(
-    writer: &mut impl Write,
-    labels: impl Iterator<Item = (&'a str, &'a str)> + 'a,
-) -> fmt::Result {
-    let mut is_first = true;
-    let mut labels = labels.peekable();
-    while let Some((key, value)) = labels.next() {
-        let is_last = labels.peek().is_none();
-        if is_first {
-            writer.write_char('{')?;
-            is_first = false;
-        }
-        writer.write_str(key)?;
-        writer.write_str("=\"")?;
-        writer.write_str(value)?;
-        writer.write_str("\"")?;
-        if is_last {
-            writer.write_char('}')?;
-        } else {
-            writer.write_char(',')?;
-        }
-    }
-    Ok(())
-}
-
-fn encode_u64(writer: &mut impl Write, v: u64) -> fmt::Result {
+pub(crate) fn encode_u64(writer: &mut impl Write, v: u64) -> fmt::Result {
     writer.write_str(itoa::Buffer::new().format(v))?;
     Ok(())
 }
 
-fn encode_i64(writer: &mut impl Write, v: i64) -> fmt::Result {
+pub(crate) fn encode_i64(writer: &mut impl Write, v: i64) -> fmt::Result {
     writer.write_str(itoa::Buffer::new().format(v))?;
     Ok(())
 }
 
-fn encode_f64(writer: &mut impl Write, v: f64) -> fmt::Result {
+pub(crate) fn encode_f64(writer: &mut impl Write, v: f64) -> fmt::Result {
     writer.write_str(ryu::Buffer::new().format(v))?;
     Ok(())
 }
 
-fn write_prefix_name(
+pub(crate) fn write_prefix_name(
     writer: &mut impl Write,
     prefixes: &[impl AsRef<str>],
     name: &str,

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -10,7 +10,10 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use crate::{MetricItem, MetricType, MetricValue, MetricsGroup, MetricsSource, RwLockRegistry};
+use crate::{
+    MetricItem, MetricType, MetricValue, MetricsGroup, MetricsSource, RwLockRegistry,
+    iterable::IntoIterable,
+};
 
 pub(crate) fn write_eof(writer: &mut impl Write) -> fmt::Result {
     writer.write_str("# EOF\n")
@@ -48,14 +51,15 @@ pub(crate) fn encode_value_item(values: &mut Values, value: MetricValue) {
 }
 
 /// Encodes a metric value (without HELP/TYPE headers) in OpenMetrics format.
-pub(crate) fn encode_metric_value<K, V>(
-    writer: &mut impl Write,
+pub(crate) fn encode_metric_value<W, K, V>(
+    writer: &mut W,
     name: &str,
     prefixes: &[impl AsRef<str>],
     labels: &[(K, V)],
     value: &MetricValue,
 ) -> fmt::Result
 where
+    W: Write + ?Sized,
     K: AsRef<str>,
     V: AsRef<str>,
 {
@@ -107,8 +111,9 @@ where
     Ok(())
 }
 
-fn write_labels_slice<K, V>(w: &mut impl Write, labels: &[(K, V)], le: Option<f64>) -> fmt::Result
+fn write_labels_slice<W, K, V>(w: &mut W, labels: &[(K, V)], le: Option<f64>) -> fmt::Result
 where
+    W: Write + ?Sized,
     K: AsRef<str>,
     V: AsRef<str>,
 {
@@ -476,11 +481,17 @@ impl dyn MetricsGroup {
             let labels = labels.iter().map(|(k, v)| (k.as_ref(), v.as_ref()));
             metric.encode_schema(schema, prefixes, labels);
         }
+        for family in IntoIterable::family_iter(self) {
+            family.encode_schema(schema, prefixes, labels);
+        }
     }
 
     pub(crate) fn encode_values(&self, values: &mut Values) {
         for metric in self.iter() {
             metric.encode_value(values);
+        }
+        for family in IntoIterable::family_iter(self) {
+            family.encode_values(values);
         }
     }
 
@@ -499,6 +510,9 @@ impl dyn MetricsGroup {
         for metric in self.iter() {
             let labels = labels.iter().map(|(k, v)| (k.as_ref(), v.as_ref()));
             metric.encode_openmetrics(writer, prefixes, labels)?;
+        }
+        for family in IntoIterable::family_iter(self) {
+            family.encode_openmetrics(writer, prefixes, labels)?;
         }
         Ok(())
     }
@@ -575,23 +589,23 @@ impl MetricItem<'_> {
     }
 }
 
-pub(crate) fn encode_u64(writer: &mut impl Write, v: u64) -> fmt::Result {
+pub(crate) fn encode_u64(writer: &mut (impl Write + ?Sized), v: u64) -> fmt::Result {
     writer.write_str(itoa::Buffer::new().format(v))?;
     Ok(())
 }
 
-pub(crate) fn encode_i64(writer: &mut impl Write, v: i64) -> fmt::Result {
+pub(crate) fn encode_i64(writer: &mut (impl Write + ?Sized), v: i64) -> fmt::Result {
     writer.write_str(itoa::Buffer::new().format(v))?;
     Ok(())
 }
 
-pub(crate) fn encode_f64(writer: &mut impl Write, v: f64) -> fmt::Result {
+pub(crate) fn encode_f64(writer: &mut (impl Write + ?Sized), v: f64) -> fmt::Result {
     writer.write_str(ryu::Buffer::new().format(v))?;
     Ok(())
 }
 
 pub(crate) fn write_prefix_name(
-    writer: &mut impl Write,
+    writer: &mut (impl Write + ?Sized),
     prefixes: &[impl AsRef<str>],
     name: &str,
 ) -> fmt::Result {

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -699,9 +699,8 @@ impl MetricItem<'_> {
         prefixes: &[&str],
         labels: impl Iterator<Item = (&'a str, &'a str)> + 'a,
     ) {
-        let labels_vec: Vec<_> = labels.collect();
         schema.push(
-            ItemSchema::new(self.name(), prefixes, &labels_vec, self.r#type()),
+            ItemSchema::from_label_iter(self.name(), prefixes, labels, self.r#type()),
             self.help(),
         );
     }

--- a/src/family.rs
+++ b/src/family.rs
@@ -5,22 +5,27 @@
 //! an alternative implementation should be considered due to lock contention.
 //! This was designed as such to avoid memory bloat in general use cases.
 
+#[cfg(feature = "metrics")]
+use std::collections::HashMap;
 use std::{
     borrow::Cow,
-    collections::HashMap,
     fmt::{self, Write},
     sync::Arc,
 };
 
+#[cfg(feature = "metrics")]
 use parking_lot::RwLock;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+#[cfg(feature = "metrics")]
+use crate::MetricValue;
+#[cfg(feature = "metrics")]
+use crate::encoding::{
+    encode_metric_value, encode_schema_item, encode_value_item, write_prefix_name,
+};
 use crate::{
-    Metric, MetricValue,
-    encoding::{
-        Schema, Values, encode_metric_value, encode_schema_item, encode_value_item,
-        write_prefix_name,
-    },
+    Metric,
+    encoding::{Schema, Values},
     labels::EncodeLabelSet,
 };
 
@@ -100,13 +105,21 @@ impl<'a> FamilyItem<'a> {
         prefixes: &[&str],
         labels: &[(Cow<'_, str>, Cow<'_, str>)],
     ) -> fmt::Result {
-        let labels: Vec<_> = labels.iter().map(|(k, v)| (k.as_ref(), v.as_ref())).collect();
+        let labels: Vec<_> = labels
+            .iter()
+            .map(|(k, v)| (k.as_ref(), v.as_ref()))
+            .collect();
         self.family
             .encode_openmetrics_dyn(writer, self.name, self.help, prefixes, &labels)
     }
 
     /// Encodes schema for binary encoding.
-    pub fn encode_schema(&self, schema: &mut Schema, prefixes: &[&str], labels: &[(Cow<'_, str>, Cow<'_, str>)]) {
+    pub fn encode_schema(
+        &self,
+        schema: &mut Schema,
+        prefixes: &[&str],
+        labels: &[(Cow<'_, str>, Cow<'_, str>)],
+    ) {
         self.family
             .encode_schema_dyn(schema, self.name, self.help, prefixes, labels);
     }
@@ -117,9 +130,11 @@ impl<'a> FamilyItem<'a> {
     }
 }
 
+#[cfg(feature = "metrics")]
 type Constructor<M> = Arc<dyn Fn() -> M + Send + Sync>;
 
 /// A family of metrics indexed by labels.
+#[cfg(feature = "metrics")]
 pub struct Family<L, M>
 where
     L: EncodeLabelSet,
@@ -129,6 +144,7 @@ where
     constructor: Constructor<M>,
 }
 
+#[cfg(feature = "metrics")]
 impl<L, M> Family<L, M>
 where
     L: EncodeLabelSet,
@@ -143,6 +159,7 @@ where
     }
 }
 
+#[cfg(feature = "metrics")]
 impl<L, M> Default for Family<L, M>
 where
     L: EncodeLabelSet,
@@ -153,6 +170,7 @@ where
     }
 }
 
+#[cfg(feature = "metrics")]
 impl<L, M> Family<L, M>
 where
     L: EncodeLabelSet,
@@ -293,6 +311,121 @@ where
     }
 }
 
+/// A family of metrics indexed by labels (no-op when metrics disabled).
+#[cfg(not(feature = "metrics"))]
+pub struct Family<L, M>
+where
+    L: EncodeLabelSet,
+    M: Metric,
+{
+    default_metric: Arc<M>,
+    _labels: std::marker::PhantomData<L>,
+}
+
+#[cfg(not(feature = "metrics"))]
+impl<L, M> Family<L, M>
+where
+    L: EncodeLabelSet,
+    M: Metric + Default + 'static,
+{
+    /// Creates a new family using `M::default()` for new metrics.
+    pub fn new() -> Self {
+        Self {
+            default_metric: Arc::new(M::default()),
+            _labels: std::marker::PhantomData,
+        }
+    }
+}
+
+#[cfg(not(feature = "metrics"))]
+impl<L, M> Default for Family<L, M>
+where
+    L: EncodeLabelSet,
+    M: Metric + Default + 'static,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(not(feature = "metrics"))]
+impl<L, M> Family<L, M>
+where
+    L: EncodeLabelSet,
+    M: Metric,
+{
+    /// Creates a new family with a custom constructor (useful for Histogram buckets).
+    pub fn with_constructor<F: Fn() -> M + Send + Sync + 'static>(constructor: F) -> Self {
+        Self {
+            default_metric: Arc::new(constructor()),
+            _labels: std::marker::PhantomData,
+        }
+    }
+
+    /// Gets or creates a metric for the given labels (returns default metric).
+    pub fn get_or_create(&self, _labels: &L) -> Arc<M> {
+        Arc::clone(&self.default_metric)
+    }
+
+    /// Removes the metric for the given labels (no-op).
+    pub fn remove(&self, _labels: &L) -> Option<Arc<M>> {
+        None
+    }
+
+    /// Removes all metrics (no-op).
+    pub fn clear(&self) {}
+
+    /// Returns the number of label combinations tracked.
+    pub fn len(&self) -> usize {
+        0
+    }
+
+    /// Returns true if empty.
+    pub fn is_empty(&self) -> bool {
+        true
+    }
+
+    /// Encodes to OpenMetrics text format (no-op).
+    pub fn encode_openmetrics<'a>(
+        &self,
+        _writer: &mut impl Write,
+        _name: &str,
+        _help: &str,
+        _prefixes: &[&str],
+        _registry_labels: impl Iterator<Item = (&'a str, &'a str)>,
+    ) -> fmt::Result
+    where
+        L: Ord,
+    {
+        Ok(())
+    }
+
+    /// Encodes schema for binary encoding (no-op).
+    pub fn encode_schema(
+        &self,
+        _schema: &mut Schema,
+        _name: &str,
+        _help: &str,
+        _prefixes: &[&str],
+        _registry_labels: &[(Cow<'_, str>, Cow<'_, str>)],
+    ) where
+        L: Ord,
+    {
+    }
+
+    /// Encodes values for binary encoding (no-op).
+    pub fn encode_values(&self, _values: &mut Values)
+    where
+        L: Ord,
+    {
+    }
+}
+
+// ============================================================================
+// Trait impls: metrics ENABLED
+// ============================================================================
+
+#[cfg(feature = "metrics")]
 impl<L, M> Clone for Family<L, M>
 where
     L: EncodeLabelSet,
@@ -306,6 +439,7 @@ where
     }
 }
 
+#[cfg(feature = "metrics")]
 impl<L, M> FamilyEncoder for Family<L, M>
 where
     L: EncodeLabelSet + Ord,
@@ -374,6 +508,7 @@ where
     }
 }
 
+#[cfg(feature = "metrics")]
 impl<L, M> fmt::Debug for Family<L, M>
 where
     L: EncodeLabelSet + fmt::Debug,
@@ -388,6 +523,7 @@ where
     }
 }
 
+#[cfg(feature = "metrics")]
 impl<L, M> Serialize for Family<L, M>
 where
     L: EncodeLabelSet + Serialize + Ord,
@@ -408,6 +544,7 @@ where
     }
 }
 
+#[cfg(feature = "metrics")]
 impl<'de, L, M> Deserialize<'de> for Family<L, M>
 where
     L: EncodeLabelSet + Deserialize<'de>,
@@ -424,6 +561,89 @@ where
         }
         drop(guard);
         Ok(family)
+    }
+}
+
+#[cfg(not(feature = "metrics"))]
+impl<L, M> Clone for Family<L, M>
+where
+    L: EncodeLabelSet,
+    M: Metric,
+{
+    fn clone(&self) -> Self {
+        Self {
+            default_metric: Arc::clone(&self.default_metric),
+            _labels: std::marker::PhantomData,
+        }
+    }
+}
+
+#[cfg(not(feature = "metrics"))]
+impl<L, M> FamilyEncoder for Family<L, M>
+where
+    L: EncodeLabelSet + Ord,
+    M: Metric + 'static,
+{
+    fn encode_openmetrics_dyn(
+        &self,
+        _writer: &mut dyn Write,
+        _name: &str,
+        _help: &str,
+        _prefixes: &[&str],
+        _registry_labels: &[(&str, &str)],
+    ) -> fmt::Result {
+        Ok(())
+    }
+
+    fn encode_schema_dyn(
+        &self,
+        _schema: &mut Schema,
+        _name: &str,
+        _help: &str,
+        _prefixes: &[&str],
+        _registry_labels: &[(Cow<'_, str>, Cow<'_, str>)],
+    ) {
+    }
+
+    fn encode_values_dyn(&self, _values: &mut Values) {}
+
+    fn is_empty_dyn(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(not(feature = "metrics"))]
+impl<L, M> fmt::Debug for Family<L, M>
+where
+    L: EncodeLabelSet,
+    M: Metric,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Family").field("disabled", &true).finish()
+    }
+}
+
+#[cfg(not(feature = "metrics"))]
+impl<L, M> Serialize for Family<L, M>
+where
+    L: EncodeLabelSet,
+    M: Metric,
+{
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeSeq;
+        serializer.serialize_seq(Some(0))?.end()
+    }
+}
+
+#[cfg(not(feature = "metrics"))]
+impl<'de, L, M> Deserialize<'de> for Family<L, M>
+where
+    L: EncodeLabelSet,
+    M: Metric + Default + 'static,
+{
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let _: serde::de::IgnoredAny = serde::de::Deserialize::deserialize(deserializer)?;
+        Ok(Family::new())
     }
 }
 

--- a/src/family.rs
+++ b/src/family.rs
@@ -159,8 +159,17 @@ where
 {
     inner: Arc<RwLock<HashMap<L, Arc<M>>>>,
     constructor: Constructor<M>,
-    // Set when the parent group is registered. Bumped on each new label combo
-    // so the binary encoder re-publishes the schema.
+    // Set once when the parent group is registered. Bumped on each new label
+    // combo so the binary encoder re-publishes the schema.
+    //
+    // Why `Arc<OnceLock<Arc<AtomicU64>>>` and not just `Arc<AtomicU64>`?
+    // - The counter is owned by the registry; a `Family` constructed inside a
+    //   user struct does not know about it until `Registry::register` walks
+    //   the group's families and attaches it. `OnceLock` lets us bind it
+    //   exactly once after construction without introducing a `Mutex`.
+    // - The outer `Arc` keeps that "attached" state shared between any
+    //   `Family::clone` instances (the `RwLock<HashMap>` is shared too, so
+    //   inserts on a clone must bump the same counter).
     schema_version: Arc<OnceLock<Arc<AtomicU64>>>,
 }
 
@@ -579,12 +588,49 @@ where
 #[cfg(not(feature = "metrics"))]
 impl<'de, L, M> Deserialize<'de> for Family<L, M>
 where
-    L: EncodeLabelSet,
+    L: EncodeLabelSet + Deserialize<'de>,
     M: Metric + Default + 'static,
 {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let _: serde::de::IgnoredAny = serde::de::Deserialize::deserialize(deserializer)?;
+        // Parse and discard the entries — without metrics we don't track them,
+        // but we must consume the wire format so that postcard et al. can
+        // resume reading the next field. `IgnoredAny` is not enough because
+        // postcard's deserializer doesn't implement `deserialize_ignored_any`.
+        let _: Vec<(L, crate::MetricValue)> = Vec::deserialize(deserializer)?;
         Ok(Family::new())
+    }
+}
+
+#[cfg(all(test, not(feature = "metrics")))]
+mod tests_no_metrics {
+    use std::borrow::Cow;
+
+    use serde::{Deserialize, Serialize};
+
+    use super::*;
+    use crate::{Counter, LabelPair};
+
+    #[derive(Clone, Hash, PartialEq, Eq, Debug, Serialize, Deserialize)]
+    struct TestLabels {
+        method: String,
+    }
+
+    impl EncodeLabelSet for TestLabels {
+        fn encode_label_pairs(&self) -> Vec<LabelPair<'_>> {
+            vec![(
+                "method",
+                crate::LabelValue::Str(Cow::Borrowed(&self.method)),
+            )]
+        }
+    }
+
+    #[test]
+    fn family_serde_roundtrip_no_metrics_feature() {
+        // Serialize as empty (no entries are tracked when metrics are off),
+        // deserialize back, and verify no panic / decode succeeds.
+        let family: Family<TestLabels, Counter> = Family::new();
+        let bytes = postcard::to_stdvec(&family).unwrap();
+        let _decoded: Family<TestLabels, Counter> = postcard::from_bytes(&bytes).unwrap();
     }
 }
 

--- a/src/family.rs
+++ b/src/family.rs
@@ -240,7 +240,11 @@ where
 
     /// Looks up an existing metric without creating one. Read-only fast path.
     pub fn get(&self, labels: &L) -> Option<Arc<M>> {
-        self.inner.read().expect("poisoned").get(labels).map(Arc::clone)
+        self.inner
+            .read()
+            .expect("poisoned")
+            .get(labels)
+            .map(Arc::clone)
     }
 
     /// Removes the metric for the given labels.

--- a/src/family.rs
+++ b/src/family.rs
@@ -1,12 +1,13 @@
 //! Metric families with labels.
 //!
-//! A [`Family`] is a collection of metrics indexed by label sets. Targeted for
-//! low cardinality (tens to ~100 label combinations). For high cardinality,
-//! an alternative implementation should be considered due to lock contention.
-//! This was designed as such to avoid memory bloat in general use cases.
+//! A [`Family`] is a collection of metrics indexed by label sets. Labels
+//! should be low cardinality: each unique combination becomes a separate
+//! timeseries on the backend, and the internal map grows without bound.
 
 #[cfg(feature = "metrics")]
 use std::collections::HashMap;
+#[cfg(feature = "metrics")]
+use std::sync::OnceLock;
 use std::{
     borrow::Cow,
     fmt::{self, Write},
@@ -15,36 +16,39 @@ use std::{
 
 #[cfg(feature = "metrics")]
 use parking_lot::RwLock;
+use portable_atomic::AtomicU64;
+#[cfg(feature = "metrics")]
+use portable_atomic::Ordering;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[cfg(feature = "metrics")]
 use crate::MetricValue;
 #[cfg(feature = "metrics")]
-use crate::encoding::{ItemSchema, encode_metric_value, encode_prefix_name};
+use crate::encoding::{ItemSchema, encode_help_text, encode_metric_value, encode_prefix_name};
 use crate::{
     Metric,
     encoding::{Schema, Values},
     labels::EncodeLabelSet,
 };
 
-/// Encoding interface for [`Family`] values.
+/// Type-erased encoding interface for a [`Family`].
 ///
-/// A metrics group may contain multiple families with different label and
-/// metric types. This trait provides a common interface so all families in a
-/// group can be encoded the same way, regardless of their concrete types.
+/// `Family<L, M>` is generic in both label and metric type. This trait
+/// collapses those generics so a metrics group containing multiple families
+/// can iterate them as `&dyn FamilyEncoder`.
 pub trait FamilyEncoder: Send + Sync + 'static {
     /// Encodes to OpenMetrics text format.
-    fn encode_openmetrics_fam(
+    fn encode_openmetrics(
         &self,
         writer: &mut dyn Write,
         name: &str,
         help: &str,
         prefixes: &[&str],
-        registry_labels: &[(&str, &str)],
+        registry_labels: &[(Cow<'_, str>, Cow<'_, str>)],
     ) -> fmt::Result;
 
     /// Encodes schema for binary encoding.
-    fn encode_schema_fam(
+    fn encode_schema(
         &self,
         schema: &mut Schema,
         name: &str,
@@ -53,11 +57,18 @@ pub trait FamilyEncoder: Send + Sync + 'static {
         registry_labels: &[(Cow<'_, str>, Cow<'_, str>)],
     );
 
-    /// Encodes values for binary encoding.
-    fn encode_values_fam(&self, values: &mut Values);
+    /// Encodes values for binary encoding. Order must match `encode_schema`.
+    fn encode_values(&self, values: &mut Values);
 
     /// Returns true if the family has no entries.
-    fn is_empty_fam(&self) -> bool;
+    fn is_empty(&self) -> bool;
+
+    /// Wires this family up to a registry's schema-version counter.
+    ///
+    /// Called by the registry when the parent metrics group is registered, so
+    /// that adding a new label combination (a new entry to the family) bumps
+    /// the version and re-publishes the schema on the next binary export.
+    fn attach_schema_version(&self, version: Arc<AtomicU64>);
 }
 
 /// A family metric item for iteration.
@@ -95,7 +106,7 @@ impl<'a> FamilyItem<'a> {
 
     /// Returns true if the family has no entries.
     pub fn is_empty(&self) -> bool {
-        self.family.is_empty_fam()
+        self.family.is_empty()
     }
 
     /// Encodes to OpenMetrics text format.
@@ -103,14 +114,10 @@ impl<'a> FamilyItem<'a> {
         &self,
         writer: &mut dyn fmt::Write,
         prefixes: &[&str],
-        labels: &[(Cow<'_, str>, Cow<'_, str>)],
+        registry_labels: &[(Cow<'_, str>, Cow<'_, str>)],
     ) -> fmt::Result {
-        let label_refs: Vec<_> = labels
-            .iter()
-            .map(|(k, v)| (k.as_ref(), v.as_ref()))
-            .collect();
         self.family
-            .encode_openmetrics_fam(writer, self.name, self.help, prefixes, &label_refs)
+            .encode_openmetrics(writer, self.name, self.help, prefixes, registry_labels)
     }
 
     /// Encodes schema for binary encoding.
@@ -118,15 +125,24 @@ impl<'a> FamilyItem<'a> {
         &self,
         schema: &mut Schema,
         prefixes: &[&str],
-        labels: &[(Cow<'_, str>, Cow<'_, str>)],
+        registry_labels: &[(Cow<'_, str>, Cow<'_, str>)],
     ) {
         self.family
-            .encode_schema_fam(schema, self.name, self.help, prefixes, labels);
+            .encode_schema(schema, self.name, self.help, prefixes, registry_labels);
     }
 
     /// Encodes values for binary encoding.
     pub fn encode_values(&self, values: &mut Values) {
-        self.family.encode_values_fam(values);
+        self.family.encode_values(values);
+    }
+
+    /// Attaches a schema-version counter to the underlying family.
+    ///
+    /// Used by [`Registry::register`](crate::Registry::register) to wire
+    /// every family in a metrics group up to the registry's version counter
+    /// so that adding a new label combination invalidates the cached schema.
+    pub fn attach_schema_version(&self, version: Arc<AtomicU64>) {
+        self.family.attach_schema_version(version);
     }
 }
 
@@ -145,6 +161,9 @@ where
 {
     inner: Arc<RwLock<HashMap<L, Arc<M>>>>,
     constructor: Constructor<M>,
+    // Set when the parent group is registered. Bumped on each new label combo
+    // so the binary encoder re-publishes the schema.
+    schema_version: Arc<OnceLock<Arc<AtomicU64>>>,
 }
 
 #[cfg(feature = "metrics")]
@@ -158,6 +177,7 @@ where
         Self {
             inner: Arc::new(RwLock::new(HashMap::new())),
             constructor: Arc::new(M::default),
+            schema_version: Arc::new(OnceLock::new()),
         }
     }
 }
@@ -184,10 +204,15 @@ where
         Self {
             inner: Arc::new(RwLock::new(HashMap::new())),
             constructor: Arc::new(constructor),
+            schema_version: Arc::new(OnceLock::new()),
         }
     }
 
     /// Gets or creates a metric for the given labels.
+    ///
+    /// Each call performs a `HashMap` lookup under a read lock. For hot paths
+    /// where the label set is stable, hold on to the returned `Arc<M>` and
+    /// reuse it instead of calling `get_or_create` on every record.
     pub fn get_or_create(&self, labels: &L) -> Arc<M> {
         if let Some(metric) = self.inner.read().get(labels) {
             return Arc::clone(metric);
@@ -200,7 +225,15 @@ where
 
         let metric = Arc::new((self.constructor)());
         guard.insert(labels.clone(), Arc::clone(&metric));
+        if let Some(v) = self.schema_version.get() {
+            v.fetch_add(1, Ordering::Relaxed);
+        }
         metric
+    }
+
+    /// Looks up an existing metric without creating one. Read-only fast path.
+    pub fn get(&self, labels: &L) -> Option<Arc<M>> {
+        self.inner.read().get(labels).map(Arc::clone)
     }
 
     /// Removes the metric for the given labels.
@@ -221,118 +254,6 @@ where
     /// Returns true if empty.
     pub fn is_empty(&self) -> bool {
         self.inner.read().is_empty()
-    }
-
-    /// Encodes to OpenMetrics text format.
-    pub fn encode_openmetrics<'a>(
-        &self,
-        writer: &mut (impl Write + ?Sized),
-        name: &str,
-        help: &str,
-        prefixes: &[&str],
-        registry_labels: impl Iterator<Item = (&'a str, &'a str)>,
-    ) -> fmt::Result
-    where
-        L: Ord,
-    {
-        let reg_labels: Vec<_> = registry_labels
-            .map(|(k, v)| (k.to_string(), v.to_string()))
-            .collect();
-        self.encode_openmetrics_impl(writer, name, help, prefixes, &reg_labels)
-    }
-
-    fn encode_openmetrics_impl(
-        &self,
-        writer: &mut (impl Write + ?Sized),
-        name: &str,
-        help: &str,
-        prefixes: &[&str],
-        registry_labels: &[(String, String)],
-    ) -> fmt::Result
-    where
-        L: Ord,
-    {
-        let guard = self.inner.read();
-        if guard.is_empty() {
-            return Ok(());
-        }
-
-        let mut entries: Vec<_> = guard.iter().collect();
-        entries.sort_by(|(a, _), (b, _)| a.cmp(b));
-
-        let metric_type = entries[0].1.r#type();
-
-        writer.write_str("# HELP ")?;
-        encode_prefix_name(writer, prefixes, name)?;
-        writeln!(writer, " {help}.")?;
-
-        writer.write_str("# TYPE ")?;
-        encode_prefix_name(writer, prefixes, name)?;
-        writeln!(writer, " {}", metric_type.as_str())?;
-
-        for (label_set, metric) in entries {
-            let family_labels: Vec<_> = label_set
-                .encode_label_pairs()
-                .into_iter()
-                .map(|(k, v)| (k.to_string(), v.as_str().into_owned()))
-                .collect();
-            encode_metric_value(
-                writer,
-                name,
-                prefixes,
-                registry_labels,
-                &family_labels,
-                &metric.value(),
-            )?;
-        }
-        Ok(())
-    }
-
-    /// Encodes schema for binary encoding.
-    pub fn encode_schema(
-        &self,
-        schema: &mut Schema,
-        name: &str,
-        help: &str,
-        prefixes: &[&str],
-        registry_labels: &[(Cow<'_, str>, Cow<'_, str>)],
-    ) where
-        L: Ord,
-    {
-        let guard = self.inner.read();
-        let mut entries: Vec<_> = guard.iter().collect();
-        entries.sort_by(|(a, _), (b, _)| a.cmp(b));
-
-        for (labels, metric) in entries {
-            let mut all_labels: Vec<_> = registry_labels
-                .iter()
-                .map(|(k, v)| (k.to_string(), v.to_string()))
-                .collect();
-            all_labels.extend(
-                labels
-                    .encode_label_pairs()
-                    .iter()
-                    .map(|(k, v)| (k.to_string(), v.as_str().to_string())),
-            );
-            schema.push(
-                ItemSchema::new(name, prefixes, &all_labels, metric.r#type()),
-                help,
-            );
-        }
-    }
-
-    /// Encodes values for binary encoding. Order must match schema.
-    pub fn encode_values(&self, values: &mut Values)
-    where
-        L: Ord,
-    {
-        let guard = self.inner.read();
-        let mut entries: Vec<_> = guard.iter().collect();
-        entries.sort_by(|(a, _), (b, _)| a.cmp(b));
-
-        for (_, metric) in entries {
-            values.items.push(metric.value());
-        }
     }
 }
 
@@ -393,6 +314,11 @@ where
         Arc::clone(&self.default_metric)
     }
 
+    /// Looks up an existing metric without creating one (always returns `None`).
+    pub fn get(&self, _labels: &L) -> Option<Arc<M>> {
+        None
+    }
+
     /// Removes the metric for the given labels (no-op).
     pub fn remove(&self, _labels: &L) -> Option<Arc<M>> {
         None
@@ -410,41 +336,6 @@ where
     pub fn is_empty(&self) -> bool {
         true
     }
-
-    /// Encodes to OpenMetrics text format (no-op).
-    pub fn encode_openmetrics<'a>(
-        &self,
-        _writer: &mut impl Write,
-        _name: &str,
-        _help: &str,
-        _prefixes: &[&str],
-        _registry_labels: impl Iterator<Item = (&'a str, &'a str)>,
-    ) -> fmt::Result
-    where
-        L: Ord,
-    {
-        Ok(())
-    }
-
-    /// Encodes schema for binary encoding (no-op).
-    pub fn encode_schema(
-        &self,
-        _schema: &mut Schema,
-        _name: &str,
-        _help: &str,
-        _prefixes: &[&str],
-        _registry_labels: &[(Cow<'_, str>, Cow<'_, str>)],
-    ) where
-        L: Ord,
-    {
-    }
-
-    /// Encodes values for binary encoding (no-op).
-    pub fn encode_values(&self, _values: &mut Values)
-    where
-        L: Ord,
-    {
-    }
 }
 
 // ============================================================================
@@ -461,6 +352,7 @@ where
         Self {
             inner: Arc::clone(&self.inner),
             constructor: Arc::clone(&self.constructor),
+            schema_version: Arc::clone(&self.schema_version),
         }
     }
 }
@@ -471,22 +363,48 @@ where
     L: EncodeLabelSet + Ord,
     M: Metric + 'static,
 {
-    fn encode_openmetrics_fam(
+    fn encode_openmetrics(
         &self,
         writer: &mut dyn Write,
         name: &str,
         help: &str,
         prefixes: &[&str],
-        registry_labels: &[(&str, &str)],
+        registry_labels: &[(Cow<'_, str>, Cow<'_, str>)],
     ) -> fmt::Result {
-        let reg_labels: Vec<_> = registry_labels
-            .iter()
-            .map(|(k, v)| (k.to_string(), v.to_string()))
-            .collect();
-        self.encode_openmetrics_impl(writer, name, help, prefixes, &reg_labels)
+        let guard = self.inner.read();
+        if guard.is_empty() {
+            return Ok(());
+        }
+
+        let mut entries: Vec<_> = guard.iter().collect();
+        entries.sort_by_key(|(a, _)| *a);
+
+        let metric_type = entries[0].1.r#type();
+
+        writer.write_str("# HELP ")?;
+        encode_prefix_name(writer, prefixes, name)?;
+        writer.write_str(" ")?;
+        encode_help_text(writer, help)?;
+
+        writer.write_str("# TYPE ")?;
+        encode_prefix_name(writer, prefixes, name)?;
+        writeln!(writer, " {}", metric_type.as_str())?;
+
+        for (label_set, metric) in entries {
+            let pairs = label_set.encode_label_pairs();
+            encode_metric_value(
+                writer,
+                name,
+                prefixes,
+                registry_labels,
+                &pairs,
+                &metric.value(),
+            )?;
+        }
+        Ok(())
     }
 
-    fn encode_schema_fam(
+    fn encode_schema(
         &self,
         schema: &mut Schema,
         name: &str,
@@ -494,15 +412,39 @@ where
         prefixes: &[&str],
         registry_labels: &[(Cow<'_, str>, Cow<'_, str>)],
     ) {
-        self.encode_schema(schema, name, help, prefixes, registry_labels);
+        let guard = self.inner.read();
+        let mut entries: Vec<_> = guard.iter().collect();
+        entries.sort_by_key(|(a, _)| *a);
+
+        for (labels, metric) in entries {
+            let pairs = labels.encode_label_pairs();
+            let all_labels = registry_labels
+                .iter()
+                .map(|(k, v)| (k.as_ref(), v.as_ref().into()))
+                .chain(pairs.iter().map(|(k, v)| (*k, v.as_str())));
+            schema.push(
+                ItemSchema::from_label_iter(name, prefixes, all_labels, metric.r#type()),
+                help,
+            );
+        }
     }
 
-    fn encode_values_fam(&self, values: &mut Values) {
-        self.encode_values(values);
+    fn encode_values(&self, values: &mut Values) {
+        let guard = self.inner.read();
+        let mut entries: Vec<_> = guard.iter().collect();
+        entries.sort_by_key(|(a, _)| *a);
+
+        for (_, metric) in entries {
+            values.items.push(metric.value());
+        }
     }
 
-    fn is_empty_fam(&self) -> bool {
-        self.is_empty()
+    fn is_empty(&self) -> bool {
+        Family::is_empty(self)
+    }
+
+    fn attach_schema_version(&self, version: Arc<AtomicU64>) {
+        let _ = self.schema_version.set(version);
     }
 }
 
@@ -532,7 +474,7 @@ where
 
         let guard = self.inner.read();
         let mut entries: Vec<_> = guard.iter().collect();
-        entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+        entries.sort_by_key(|(a, _)| *a);
 
         let mut seq = serializer.serialize_seq(Some(entries.len()))?;
         for (labels, metric) in entries {
@@ -583,18 +525,18 @@ where
     L: EncodeLabelSet + Ord,
     M: Metric + 'static,
 {
-    fn encode_openmetrics_fam(
+    fn encode_openmetrics(
         &self,
         _writer: &mut dyn Write,
         _name: &str,
         _help: &str,
         _prefixes: &[&str],
-        _registry_labels: &[(&str, &str)],
+        _registry_labels: &[(Cow<'_, str>, Cow<'_, str>)],
     ) -> fmt::Result {
         Ok(())
     }
 
-    fn encode_schema_fam(
+    fn encode_schema(
         &self,
         _schema: &mut Schema,
         _name: &str,
@@ -604,11 +546,13 @@ where
     ) {
     }
 
-    fn encode_values_fam(&self, _values: &mut Values) {}
+    fn encode_values(&self, _values: &mut Values) {}
 
-    fn is_empty_fam(&self) -> bool {
+    fn is_empty(&self) -> bool {
         true
     }
+
+    fn attach_schema_version(&self, _version: Arc<AtomicU64>) {}
 }
 
 #[cfg(not(feature = "metrics"))]
@@ -734,15 +678,15 @@ mod tests {
 
         // OpenMetrics without registry labels
         let mut out = String::new();
-        family
-            .encode_openmetrics(
-                &mut out,
-                "requests",
-                "HTTP requests",
-                &["http"],
-                std::iter::empty(),
-            )
-            .unwrap();
+        FamilyEncoder::encode_openmetrics(
+            &family,
+            &mut out,
+            "requests",
+            "HTTP requests",
+            &["http"],
+            &[],
+        )
+        .unwrap();
         assert!(out.contains("# HELP http_requests HTTP requests."));
         assert!(out.contains("# TYPE http_requests counter"));
         assert!(out.contains(r#"http_requests_total{method="GET",status="200"} 10"#));
@@ -750,24 +694,32 @@ mod tests {
 
         // OpenMetrics with registry labels
         let mut out = String::new();
-        family
-            .encode_openmetrics(
-                &mut out,
-                "requests",
-                "HTTP requests",
-                &["http"],
-                [("service", "api")].into_iter(),
-            )
-            .unwrap();
+        let registry_labels = [(Cow::Borrowed("service"), Cow::Borrowed("api"))];
+        FamilyEncoder::encode_openmetrics(
+            &family,
+            &mut out,
+            "requests",
+            "HTTP requests",
+            &["http"],
+            &registry_labels,
+        )
+        .unwrap();
         assert!(out.contains(r#"http_requests_total{service="api",method="GET",status="200"} 10"#));
 
         // Binary schema + values
         let mut schema = Schema::default();
-        family.encode_schema(&mut schema, "requests", "HTTP requests", &["http"], &[]);
+        FamilyEncoder::encode_schema(
+            &family,
+            &mut schema,
+            "requests",
+            "HTTP requests",
+            &["http"],
+            &[],
+        );
         assert_eq!(schema.items.len(), 2);
 
         let mut values = Values::default();
-        family.encode_values(&mut values);
+        FamilyEncoder::encode_values(&family, &mut values);
         assert_eq!(values.items.len(), 2);
     }
 }

--- a/src/family.rs
+++ b/src/family.rs
@@ -20,21 +20,21 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "metrics")]
 use crate::MetricValue;
 #[cfg(feature = "metrics")]
-use crate::encoding::{
-    encode_metric_value, encode_schema_item, encode_value_item, write_prefix_name,
-};
+use crate::encoding::{ItemSchema, encode_metric_value, encode_prefix_name};
 use crate::{
     Metric,
     encoding::{Schema, Values},
     labels::EncodeLabelSet,
 };
 
-/// Trait for type-erased Family encoding.
+/// Encoding interface for [`Family`] values.
 ///
-/// Implemented by `Family<L, M>` to enable dynamic dispatch in derive macros.
+/// A metrics group may contain multiple families with different label and
+/// metric types. This trait provides a common interface so all families in a
+/// group can be encoded the same way, regardless of their concrete types.
 pub trait FamilyEncoder: Send + Sync + 'static {
     /// Encodes to OpenMetrics text format.
-    fn encode_openmetrics_dyn(
+    fn encode_openmetrics_fam(
         &self,
         writer: &mut dyn Write,
         name: &str,
@@ -44,7 +44,7 @@ pub trait FamilyEncoder: Send + Sync + 'static {
     ) -> fmt::Result;
 
     /// Encodes schema for binary encoding.
-    fn encode_schema_dyn(
+    fn encode_schema_fam(
         &self,
         schema: &mut Schema,
         name: &str,
@@ -54,10 +54,10 @@ pub trait FamilyEncoder: Send + Sync + 'static {
     );
 
     /// Encodes values for binary encoding.
-    fn encode_values_dyn(&self, values: &mut Values);
+    fn encode_values_fam(&self, values: &mut Values);
 
     /// Returns true if the family has no entries.
-    fn is_empty_dyn(&self) -> bool;
+    fn is_empty_fam(&self) -> bool;
 }
 
 /// A family metric item for iteration.
@@ -95,7 +95,7 @@ impl<'a> FamilyItem<'a> {
 
     /// Returns true if the family has no entries.
     pub fn is_empty(&self) -> bool {
-        self.family.is_empty_dyn()
+        self.family.is_empty_fam()
     }
 
     /// Encodes to OpenMetrics text format.
@@ -110,7 +110,7 @@ impl<'a> FamilyItem<'a> {
             .map(|(k, v)| (k.as_ref(), v.as_ref()))
             .collect();
         self.family
-            .encode_openmetrics_dyn(writer, self.name, self.help, prefixes, &label_refs)
+            .encode_openmetrics_fam(writer, self.name, self.help, prefixes, &label_refs)
     }
 
     /// Encodes schema for binary encoding.
@@ -121,12 +121,12 @@ impl<'a> FamilyItem<'a> {
         labels: &[(Cow<'_, str>, Cow<'_, str>)],
     ) {
         self.family
-            .encode_schema_dyn(schema, self.name, self.help, prefixes, labels);
+            .encode_schema_fam(schema, self.name, self.help, prefixes, labels);
     }
 
     /// Encodes values for binary encoding.
     pub fn encode_values(&self, values: &mut Values) {
-        self.family.encode_values_dyn(values);
+        self.family.encode_values_fam(values);
     }
 }
 
@@ -134,6 +134,9 @@ impl<'a> FamilyItem<'a> {
 type Constructor<M> = Arc<dyn Fn() -> M + Send + Sync>;
 
 /// A family of metrics indexed by labels.
+///
+/// Thread-safe: multiple threads can look up or create metrics concurrently.
+/// Each metric is reference-counted so it can be used independently after lookup.
 #[cfg(feature = "metrics")]
 pub struct Family<L, M>
 where
@@ -260,22 +263,27 @@ where
         let metric_type = entries[0].1.r#type();
 
         writer.write_str("# HELP ")?;
-        write_prefix_name(writer, prefixes, name)?;
+        encode_prefix_name(writer, prefixes, name)?;
         writeln!(writer, " {help}.")?;
 
         writer.write_str("# TYPE ")?;
-        write_prefix_name(writer, prefixes, name)?;
+        encode_prefix_name(writer, prefixes, name)?;
         writeln!(writer, " {}", metric_type.as_str())?;
 
         for (label_set, metric) in entries {
-            let mut all_labels = registry_labels.to_vec();
-            all_labels.extend(
-                label_set
-                    .encode_label_pairs()
-                    .into_iter()
-                    .map(|(k, v)| (k.to_string(), v.as_str().into_owned())),
-            );
-            encode_metric_value(writer, name, prefixes, &all_labels, &metric.value())?;
+            let family_labels: Vec<_> = label_set
+                .encode_label_pairs()
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v.as_str().into_owned()))
+                .collect();
+            encode_metric_value(
+                writer,
+                name,
+                prefixes,
+                registry_labels,
+                &family_labels,
+                &metric.value(),
+            )?;
         }
         Ok(())
     }
@@ -306,7 +314,10 @@ where
                     .iter()
                     .map(|(k, v)| (k.to_string(), v.as_str().to_string())),
             );
-            encode_schema_item(schema, name, help, prefixes, &all_labels, metric.r#type());
+            schema.push(
+                ItemSchema::new(name, prefixes, &all_labels, metric.r#type()),
+                help,
+            );
         }
     }
 
@@ -320,7 +331,7 @@ where
         entries.sort_by(|(a, _), (b, _)| a.cmp(b));
 
         for (_, metric) in entries {
-            encode_value_item(values, metric.value());
+            values.items.push(metric.value());
         }
     }
 }
@@ -332,6 +343,7 @@ where
     L: EncodeLabelSet,
     M: Metric,
 {
+    /// Shared no-op / placeholder metric returned by all `get_or_create` calls when metrics are disabled.
     default_metric: Arc<M>,
     _labels: std::marker::PhantomData<L>,
 }
@@ -459,7 +471,7 @@ where
     L: EncodeLabelSet + Ord,
     M: Metric + 'static,
 {
-    fn encode_openmetrics_dyn(
+    fn encode_openmetrics_fam(
         &self,
         writer: &mut dyn Write,
         name: &str,
@@ -474,7 +486,7 @@ where
         self.encode_openmetrics_impl(writer, name, help, prefixes, &reg_labels)
     }
 
-    fn encode_schema_dyn(
+    fn encode_schema_fam(
         &self,
         schema: &mut Schema,
         name: &str,
@@ -485,11 +497,11 @@ where
         self.encode_schema(schema, name, help, prefixes, registry_labels);
     }
 
-    fn encode_values_dyn(&self, values: &mut Values) {
+    fn encode_values_fam(&self, values: &mut Values) {
         self.encode_values(values);
     }
 
-    fn is_empty_dyn(&self) -> bool {
+    fn is_empty_fam(&self) -> bool {
         self.is_empty()
     }
 }
@@ -571,7 +583,7 @@ where
     L: EncodeLabelSet + Ord,
     M: Metric + 'static,
 {
-    fn encode_openmetrics_dyn(
+    fn encode_openmetrics_fam(
         &self,
         _writer: &mut dyn Write,
         _name: &str,
@@ -582,7 +594,7 @@ where
         Ok(())
     }
 
-    fn encode_schema_dyn(
+    fn encode_schema_fam(
         &self,
         _schema: &mut Schema,
         _name: &str,
@@ -592,9 +604,9 @@ where
     ) {
     }
 
-    fn encode_values_dyn(&self, _values: &mut Values) {}
+    fn encode_values_fam(&self, _values: &mut Values) {}
 
-    fn is_empty_dyn(&self) -> bool {
+    fn is_empty_fam(&self) -> bool {
         true
     }
 }

--- a/src/family.rs
+++ b/src/family.rs
@@ -105,12 +105,12 @@ impl<'a> FamilyItem<'a> {
         prefixes: &[&str],
         labels: &[(Cow<'_, str>, Cow<'_, str>)],
     ) -> fmt::Result {
-        let labels: Vec<_> = labels
+        let label_refs: Vec<_> = labels
             .iter()
             .map(|(k, v)| (k.as_ref(), v.as_ref()))
             .collect();
         self.family
-            .encode_openmetrics_dyn(writer, self.name, self.help, prefixes, &labels)
+            .encode_openmetrics_dyn(writer, self.name, self.help, prefixes, &label_refs)
     }
 
     /// Encodes schema for binary encoding.
@@ -223,11 +223,28 @@ where
     /// Encodes to OpenMetrics text format.
     pub fn encode_openmetrics<'a>(
         &self,
-        writer: &mut impl Write,
+        writer: &mut (impl Write + ?Sized),
         name: &str,
         help: &str,
         prefixes: &[&str],
         registry_labels: impl Iterator<Item = (&'a str, &'a str)>,
+    ) -> fmt::Result
+    where
+        L: Ord,
+    {
+        let reg_labels: Vec<_> = registry_labels
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        self.encode_openmetrics_impl(writer, name, help, prefixes, &reg_labels)
+    }
+
+    fn encode_openmetrics_impl(
+        &self,
+        writer: &mut (impl Write + ?Sized),
+        name: &str,
+        help: &str,
+        prefixes: &[&str],
+        registry_labels: &[(String, String)],
     ) -> fmt::Result
     where
         L: Ord,
@@ -241,9 +258,6 @@ where
         entries.sort_by(|(a, _), (b, _)| a.cmp(b));
 
         let metric_type = entries[0].1.r#type();
-        let reg_labels: Vec<_> = registry_labels
-            .map(|(k, v)| (k.to_string(), v.to_string()))
-            .collect();
 
         writer.write_str("# HELP ")?;
         write_prefix_name(writer, prefixes, name)?;
@@ -253,10 +267,10 @@ where
         write_prefix_name(writer, prefixes, name)?;
         writeln!(writer, " {}", metric_type.as_str())?;
 
-        for (labels, metric) in entries {
-            let mut all_labels = reg_labels.clone();
+        for (label_set, metric) in entries {
+            let mut all_labels = registry_labels.to_vec();
             all_labels.extend(
-                labels
+                label_set
                     .encode_label_pairs()
                     .into_iter()
                     .map(|(k, v)| (k.to_string(), v.as_str().into_owned())),
@@ -453,39 +467,11 @@ where
         prefixes: &[&str],
         registry_labels: &[(&str, &str)],
     ) -> fmt::Result {
-        let guard = self.inner.read();
-        if guard.is_empty() {
-            return Ok(());
-        }
-
-        let mut entries: Vec<_> = guard.iter().collect();
-        entries.sort_by(|(a, _), (b, _)| a.cmp(b));
-
-        let metric_type = entries[0].1.r#type();
         let reg_labels: Vec<_> = registry_labels
             .iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
-
-        writer.write_str("# HELP ")?;
-        write_prefix_name(writer, prefixes, name)?;
-        writeln!(writer, " {help}.")?;
-
-        writer.write_str("# TYPE ")?;
-        write_prefix_name(writer, prefixes, name)?;
-        writeln!(writer, " {}", metric_type.as_str())?;
-
-        for (labels, metric) in entries {
-            let mut all_labels = reg_labels.clone();
-            all_labels.extend(
-                labels
-                    .encode_label_pairs()
-                    .into_iter()
-                    .map(|(k, v)| (k.to_string(), v.as_str().into_owned())),
-            );
-            encode_metric_value(writer, name, prefixes, &all_labels, &metric.value())?;
-        }
-        Ok(())
+        self.encode_openmetrics_impl(writer, name, help, prefixes, &reg_labels)
     }
 
     fn encode_schema_dyn(
@@ -553,13 +539,14 @@ where
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let entries: Vec<(L, MetricValue)> = Vec::deserialize(deserializer)?;
         let family = Family::new();
-        let mut guard = family.inner.write();
-        for (labels, value) in entries {
-            let metric = Arc::new(M::default());
-            metric.set_value(value);
-            guard.insert(labels, metric);
+        {
+            let mut guard = family.inner.write();
+            for (labels, value) in entries {
+                let metric = Arc::new(M::default());
+                metric.set_value(value);
+                guard.insert(labels, metric);
+            }
         }
-        drop(guard);
         Ok(family)
     }
 }

--- a/src/family.rs
+++ b/src/family.rs
@@ -24,6 +24,99 @@ use crate::{
     labels::EncodeLabelSet,
 };
 
+/// Trait for type-erased Family encoding.
+///
+/// Implemented by `Family<L, M>` to enable dynamic dispatch in derive macros.
+pub trait FamilyEncoder: Send + Sync + 'static {
+    /// Encodes to OpenMetrics text format.
+    fn encode_openmetrics_dyn(
+        &self,
+        writer: &mut dyn Write,
+        name: &str,
+        help: &str,
+        prefixes: &[&str],
+        registry_labels: &[(&str, &str)],
+    ) -> fmt::Result;
+
+    /// Encodes schema for binary encoding.
+    fn encode_schema_dyn(
+        &self,
+        schema: &mut Schema,
+        name: &str,
+        help: &str,
+        prefixes: &[&str],
+        registry_labels: &[(Cow<'_, str>, Cow<'_, str>)],
+    );
+
+    /// Encodes values for binary encoding.
+    fn encode_values_dyn(&self, values: &mut Values);
+
+    /// Returns true if the family has no entries.
+    fn is_empty_dyn(&self) -> bool;
+}
+
+/// A family metric item for iteration.
+#[derive(Clone, Copy)]
+pub struct FamilyItem<'a> {
+    pub(crate) name: &'static str,
+    pub(crate) help: &'static str,
+    pub(crate) family: &'a dyn FamilyEncoder,
+}
+
+impl fmt::Debug for FamilyItem<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FamilyItem")
+            .field("name", &self.name)
+            .field("help", &self.help)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'a> FamilyItem<'a> {
+    /// Creates a new family item.
+    pub fn new(name: &'static str, help: &'static str, family: &'a dyn FamilyEncoder) -> Self {
+        Self { name, help, family }
+    }
+
+    /// Returns the name of this family.
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// Returns the help text of this family.
+    pub fn help(&self) -> &'static str {
+        self.help
+    }
+
+    /// Returns true if the family has no entries.
+    pub fn is_empty(&self) -> bool {
+        self.family.is_empty_dyn()
+    }
+
+    /// Encodes to OpenMetrics text format.
+    pub fn encode_openmetrics(
+        &self,
+        writer: &mut dyn fmt::Write,
+        prefixes: &[&str],
+        labels: &[(Cow<'_, str>, Cow<'_, str>)],
+    ) -> fmt::Result {
+        let labels: Vec<_> = labels.iter().map(|(k, v)| (k.as_ref(), v.as_ref())).collect();
+        self.family
+            .encode_openmetrics_dyn(writer, self.name, self.help, prefixes, &labels)
+    }
+
+    /// Encodes schema for binary encoding.
+    pub fn encode_schema(&self, schema: &mut Schema, prefixes: &[&str], labels: &[(Cow<'_, str>, Cow<'_, str>)]) {
+        self.family
+            .encode_schema_dyn(schema, self.name, self.help, prefixes, labels);
+    }
+
+    /// Encodes values for binary encoding.
+    pub fn encode_values(&self, values: &mut Values) {
+        self.family.encode_values_dyn(values);
+    }
+}
+
 type Constructor<M> = Arc<dyn Fn() -> M + Send + Sync>;
 
 /// A family of metrics indexed by labels.
@@ -210,6 +303,74 @@ where
             inner: Arc::clone(&self.inner),
             constructor: Arc::clone(&self.constructor),
         }
+    }
+}
+
+impl<L, M> FamilyEncoder for Family<L, M>
+where
+    L: EncodeLabelSet + Ord,
+    M: Metric + 'static,
+{
+    fn encode_openmetrics_dyn(
+        &self,
+        writer: &mut dyn Write,
+        name: &str,
+        help: &str,
+        prefixes: &[&str],
+        registry_labels: &[(&str, &str)],
+    ) -> fmt::Result {
+        let guard = self.inner.read();
+        if guard.is_empty() {
+            return Ok(());
+        }
+
+        let mut entries: Vec<_> = guard.iter().collect();
+        entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+        let metric_type = entries[0].1.r#type();
+        let reg_labels: Vec<_> = registry_labels
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+
+        writer.write_str("# HELP ")?;
+        write_prefix_name(writer, prefixes, name)?;
+        writeln!(writer, " {help}.")?;
+
+        writer.write_str("# TYPE ")?;
+        write_prefix_name(writer, prefixes, name)?;
+        writeln!(writer, " {}", metric_type.as_str())?;
+
+        for (labels, metric) in entries {
+            let mut all_labels = reg_labels.clone();
+            all_labels.extend(
+                labels
+                    .encode_label_pairs()
+                    .into_iter()
+                    .map(|(k, v)| (k.to_string(), v.as_str().into_owned())),
+            );
+            encode_metric_value(writer, name, prefixes, &all_labels, &metric.value())?;
+        }
+        Ok(())
+    }
+
+    fn encode_schema_dyn(
+        &self,
+        schema: &mut Schema,
+        name: &str,
+        help: &str,
+        prefixes: &[&str],
+        registry_labels: &[(Cow<'_, str>, Cow<'_, str>)],
+    ) {
+        self.encode_schema(schema, name, help, prefixes, registry_labels);
+    }
+
+    fn encode_values_dyn(&self, values: &mut Values) {
+        self.encode_values(values);
+    }
+
+    fn is_empty_dyn(&self) -> bool {
+        self.is_empty()
     }
 }
 

--- a/src/family.rs
+++ b/src/family.rs
@@ -7,15 +7,13 @@
 #[cfg(feature = "metrics")]
 use std::collections::HashMap;
 #[cfg(feature = "metrics")]
-use std::sync::OnceLock;
+use std::sync::{OnceLock, RwLock};
 use std::{
     borrow::Cow,
     fmt::{self, Write},
     sync::Arc,
 };
 
-#[cfg(feature = "metrics")]
-use parking_lot::RwLock;
 use portable_atomic::AtomicU64;
 #[cfg(feature = "metrics")]
 use portable_atomic::Ordering;
@@ -214,11 +212,11 @@ where
     /// where the label set is stable, hold on to the returned `Arc<M>` and
     /// reuse it instead of calling `get_or_create` on every record.
     pub fn get_or_create(&self, labels: &L) -> Arc<M> {
-        if let Some(metric) = self.inner.read().get(labels) {
+        if let Some(metric) = self.inner.read().expect("poisoned").get(labels) {
             return Arc::clone(metric);
         }
 
-        let mut guard = self.inner.write();
+        let mut guard = self.inner.write().expect("poisoned");
         if let Some(metric) = guard.get(labels) {
             return Arc::clone(metric);
         }
@@ -233,27 +231,27 @@ where
 
     /// Looks up an existing metric without creating one. Read-only fast path.
     pub fn get(&self, labels: &L) -> Option<Arc<M>> {
-        self.inner.read().get(labels).map(Arc::clone)
+        self.inner.read().expect("poisoned").get(labels).map(Arc::clone)
     }
 
     /// Removes the metric for the given labels.
     pub fn remove(&self, labels: &L) -> Option<Arc<M>> {
-        self.inner.write().remove(labels)
+        self.inner.write().expect("poisoned").remove(labels)
     }
 
     /// Removes all metrics.
     pub fn clear(&self) {
-        self.inner.write().clear();
+        self.inner.write().expect("poisoned").clear();
     }
 
     /// Returns the number of label combinations tracked.
     pub fn len(&self) -> usize {
-        self.inner.read().len()
+        self.inner.read().expect("poisoned").len()
     }
 
     /// Returns true if empty.
     pub fn is_empty(&self) -> bool {
-        self.inner.read().is_empty()
+        self.inner.read().expect("poisoned").is_empty()
     }
 }
 
@@ -371,7 +369,7 @@ where
         prefixes: &[&str],
         registry_labels: &[(Cow<'_, str>, Cow<'_, str>)],
     ) -> fmt::Result {
-        let guard = self.inner.read();
+        let guard = self.inner.read().expect("poisoned");
         if guard.is_empty() {
             return Ok(());
         }
@@ -412,7 +410,7 @@ where
         prefixes: &[&str],
         registry_labels: &[(Cow<'_, str>, Cow<'_, str>)],
     ) {
-        let guard = self.inner.read();
+        let guard = self.inner.read().expect("poisoned");
         let mut entries: Vec<_> = guard.iter().collect();
         entries.sort_by_key(|(a, _)| *a);
 
@@ -430,7 +428,7 @@ where
     }
 
     fn encode_values(&self, values: &mut Values) {
-        let guard = self.inner.read();
+        let guard = self.inner.read().expect("poisoned");
         let mut entries: Vec<_> = guard.iter().collect();
         entries.sort_by_key(|(a, _)| *a);
 
@@ -455,7 +453,7 @@ where
     M: Metric,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let guard = self.inner.read();
+        let guard = self.inner.read().expect("poisoned");
         f.debug_struct("Family")
             .field("len", &guard.len())
             .field("labels", &guard.keys().collect::<Vec<_>>())
@@ -472,7 +470,7 @@ where
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         use serde::ser::SerializeSeq;
 
-        let guard = self.inner.read();
+        let guard = self.inner.read().expect("poisoned");
         let mut entries: Vec<_> = guard.iter().collect();
         entries.sort_by_key(|(a, _)| *a);
 
@@ -494,7 +492,7 @@ where
         let entries: Vec<(L, MetricValue)> = Vec::deserialize(deserializer)?;
         let family = Family::new();
         {
-            let mut guard = family.inner.write();
+            let mut guard = family.inner.write().expect("poisoned");
             for (labels, value) in entries {
                 let metric = Arc::new(M::default());
                 metric.set_value(value);

--- a/src/family.rs
+++ b/src/family.rs
@@ -1,0 +1,393 @@
+//! Metric families with labels.
+//!
+//! A [`Family`] is a collection of metrics indexed by label sets. Targeted for
+//! low cardinality (tens to ~100 label combinations). For high cardinality,
+//! an alternative implementation should be considered due to lock contention.
+//! This was designed as such to avoid memory bloat in general use cases.
+
+use std::{
+    borrow::Cow,
+    collections::HashMap,
+    fmt::{self, Write},
+    sync::Arc,
+};
+
+use parking_lot::RwLock;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::{
+    Metric, MetricValue,
+    encoding::{
+        Schema, Values, encode_metric_value, encode_schema_item, encode_value_item,
+        write_prefix_name,
+    },
+    labels::EncodeLabelSet,
+};
+
+type Constructor<M> = Arc<dyn Fn() -> M + Send + Sync>;
+
+/// A family of metrics indexed by labels.
+pub struct Family<L, M>
+where
+    L: EncodeLabelSet,
+    M: Metric,
+{
+    inner: Arc<RwLock<HashMap<L, Arc<M>>>>,
+    constructor: Constructor<M>,
+}
+
+impl<L, M> Family<L, M>
+where
+    L: EncodeLabelSet,
+    M: Metric + Default + 'static,
+{
+    /// Creates a new family using `M::default()` for new metrics.
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(HashMap::new())),
+            constructor: Arc::new(M::default),
+        }
+    }
+}
+
+impl<L, M> Default for Family<L, M>
+where
+    L: EncodeLabelSet,
+    M: Metric + Default + 'static,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<L, M> Family<L, M>
+where
+    L: EncodeLabelSet,
+    M: Metric,
+{
+    /// Creates a new family with a custom constructor (useful for Histogram buckets).
+    pub fn with_constructor<F: Fn() -> M + Send + Sync + 'static>(constructor: F) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(HashMap::new())),
+            constructor: Arc::new(constructor),
+        }
+    }
+
+    /// Gets or creates a metric for the given labels.
+    pub fn get_or_create(&self, labels: &L) -> Arc<M> {
+        if let Some(metric) = self.inner.read().get(labels) {
+            return Arc::clone(metric);
+        }
+
+        let mut guard = self.inner.write();
+        if let Some(metric) = guard.get(labels) {
+            return Arc::clone(metric);
+        }
+
+        let metric = Arc::new((self.constructor)());
+        guard.insert(labels.clone(), Arc::clone(&metric));
+        metric
+    }
+
+    /// Removes the metric for the given labels.
+    pub fn remove(&self, labels: &L) -> Option<Arc<M>> {
+        self.inner.write().remove(labels)
+    }
+
+    /// Removes all metrics.
+    pub fn clear(&self) {
+        self.inner.write().clear();
+    }
+
+    /// Returns the number of label combinations tracked.
+    pub fn len(&self) -> usize {
+        self.inner.read().len()
+    }
+
+    /// Returns true if empty.
+    pub fn is_empty(&self) -> bool {
+        self.inner.read().is_empty()
+    }
+
+    /// Encodes to OpenMetrics text format.
+    pub fn encode_openmetrics<'a>(
+        &self,
+        writer: &mut impl Write,
+        name: &str,
+        help: &str,
+        prefixes: &[&str],
+        registry_labels: impl Iterator<Item = (&'a str, &'a str)>,
+    ) -> fmt::Result
+    where
+        L: Ord,
+    {
+        let guard = self.inner.read();
+        if guard.is_empty() {
+            return Ok(());
+        }
+
+        let mut entries: Vec<_> = guard.iter().collect();
+        entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+        let metric_type = entries[0].1.r#type();
+        let reg_labels: Vec<_> = registry_labels
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+
+        writer.write_str("# HELP ")?;
+        write_prefix_name(writer, prefixes, name)?;
+        writeln!(writer, " {help}.")?;
+
+        writer.write_str("# TYPE ")?;
+        write_prefix_name(writer, prefixes, name)?;
+        writeln!(writer, " {}", metric_type.as_str())?;
+
+        for (labels, metric) in entries {
+            let mut all_labels = reg_labels.clone();
+            all_labels.extend(
+                labels
+                    .encode_label_pairs()
+                    .into_iter()
+                    .map(|(k, v)| (k.to_string(), v.as_str().into_owned())),
+            );
+            encode_metric_value(writer, name, prefixes, &all_labels, &metric.value())?;
+        }
+        Ok(())
+    }
+
+    /// Encodes schema for binary encoding.
+    pub fn encode_schema(
+        &self,
+        schema: &mut Schema,
+        name: &str,
+        help: &str,
+        prefixes: &[&str],
+        registry_labels: &[(Cow<'_, str>, Cow<'_, str>)],
+    ) where
+        L: Ord,
+    {
+        let guard = self.inner.read();
+        let mut entries: Vec<_> = guard.iter().collect();
+        entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+        for (labels, metric) in entries {
+            let mut all_labels: Vec<_> = registry_labels
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect();
+            all_labels.extend(
+                labels
+                    .encode_label_pairs()
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.as_str().to_string())),
+            );
+            encode_schema_item(schema, name, help, prefixes, &all_labels, metric.r#type());
+        }
+    }
+
+    /// Encodes values for binary encoding. Order must match schema.
+    pub fn encode_values(&self, values: &mut Values)
+    where
+        L: Ord,
+    {
+        let guard = self.inner.read();
+        let mut entries: Vec<_> = guard.iter().collect();
+        entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+        for (_, metric) in entries {
+            encode_value_item(values, metric.value());
+        }
+    }
+}
+
+impl<L, M> Clone for Family<L, M>
+where
+    L: EncodeLabelSet,
+    M: Metric,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            constructor: Arc::clone(&self.constructor),
+        }
+    }
+}
+
+impl<L, M> fmt::Debug for Family<L, M>
+where
+    L: EncodeLabelSet + fmt::Debug,
+    M: Metric,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let guard = self.inner.read();
+        f.debug_struct("Family")
+            .field("len", &guard.len())
+            .field("labels", &guard.keys().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+impl<L, M> Serialize for Family<L, M>
+where
+    L: EncodeLabelSet + Serialize + Ord,
+    M: Metric,
+{
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeSeq;
+
+        let guard = self.inner.read();
+        let mut entries: Vec<_> = guard.iter().collect();
+        entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+        let mut seq = serializer.serialize_seq(Some(entries.len()))?;
+        for (labels, metric) in entries {
+            seq.serialize_element(&(labels, metric.value()))?;
+        }
+        seq.end()
+    }
+}
+
+impl<'de, L, M> Deserialize<'de> for Family<L, M>
+where
+    L: EncodeLabelSet + Deserialize<'de>,
+    M: Metric + Default + 'static,
+{
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let entries: Vec<(L, MetricValue)> = Vec::deserialize(deserializer)?;
+        let family = Family::new();
+        let mut guard = family.inner.write();
+        for (labels, value) in entries {
+            let metric = Arc::new(M::default());
+            metric.set_value(value);
+            guard.insert(labels, metric);
+        }
+        drop(guard);
+        Ok(family)
+    }
+}
+
+#[cfg(all(test, feature = "metrics"))]
+mod tests {
+    use std::borrow::Cow;
+
+    use serde::{Deserialize, Serialize};
+
+    use super::*;
+    use crate::{Counter, Histogram, LabelPair, NoLabels};
+
+    #[derive(Clone, Hash, PartialEq, Eq, Debug, PartialOrd, Ord, Serialize, Deserialize)]
+    struct TestLabels {
+        method: String,
+        status: u16,
+    }
+
+    impl EncodeLabelSet for TestLabels {
+        fn encode_label_pairs(&self) -> Vec<LabelPair<'_>> {
+            vec![
+                (
+                    "method",
+                    crate::LabelValue::Str(Cow::Borrowed(&self.method)),
+                ),
+                ("status", crate::LabelValue::Uint(self.status as u64)),
+            ]
+        }
+    }
+
+    fn labels(method: &str, status: u16) -> TestLabels {
+        TestLabels {
+            method: method.into(),
+            status,
+        }
+    }
+
+    #[test]
+    fn test_family_operations() {
+        // get_or_create returns same metric for same labels
+        let family: Family<TestLabels, Counter> = Family::new();
+        let c1 = family.get_or_create(&labels("GET", 200));
+        c1.inc();
+        let c2 = family.get_or_create(&labels("GET", 200));
+        c2.inc();
+        assert_eq!(c1.get(), 2);
+
+        // different labels get different metrics
+        family.get_or_create(&labels("GET", 404)).inc_by(5);
+        assert_eq!(family.get_or_create(&labels("GET", 404)).get(), 5);
+        assert_eq!(family.len(), 2);
+
+        // remove
+        let removed = family.remove(&labels("GET", 200));
+        assert_eq!(removed.unwrap().get(), 2);
+        assert_eq!(family.len(), 1);
+
+        // clear
+        family.get_or_create(&labels("POST", 200)).inc();
+        family.clear();
+        assert!(family.is_empty());
+
+        // with_constructor for custom metrics
+        let hist_family: Family<NoLabels, Histogram> =
+            Family::with_constructor(|| Histogram::new(vec![1.0, 5.0, 10.0]));
+        hist_family.get_or_create(&NoLabels).observe(2.5);
+        hist_family.get_or_create(&NoLabels).observe(7.5);
+        assert_eq!(hist_family.get_or_create(&NoLabels).count(), 2);
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        let family: Family<TestLabels, Counter> = Family::new();
+        family.get_or_create(&labels("GET", 200)).inc_by(10);
+        family.get_or_create(&labels("POST", 201)).inc_by(5);
+
+        let bytes = postcard::to_stdvec(&family).unwrap();
+        let decoded: Family<TestLabels, Counter> = postcard::from_bytes(&bytes).unwrap();
+
+        assert_eq!(decoded.get_or_create(&labels("GET", 200)).get(), 10);
+        assert_eq!(decoded.get_or_create(&labels("POST", 201)).get(), 5);
+    }
+
+    #[test]
+    fn test_encoding() {
+        let family: Family<TestLabels, Counter> = Family::new();
+        family.get_or_create(&labels("GET", 200)).inc_by(10);
+        family.get_or_create(&labels("POST", 201)).inc_by(5);
+
+        // OpenMetrics without registry labels
+        let mut out = String::new();
+        family
+            .encode_openmetrics(
+                &mut out,
+                "requests",
+                "HTTP requests",
+                &["http"],
+                std::iter::empty(),
+            )
+            .unwrap();
+        assert!(out.contains("# HELP http_requests HTTP requests."));
+        assert!(out.contains("# TYPE http_requests counter"));
+        assert!(out.contains(r#"http_requests_total{method="GET",status="200"} 10"#));
+        assert!(out.contains(r#"http_requests_total{method="POST",status="201"} 5"#));
+
+        // OpenMetrics with registry labels
+        let mut out = String::new();
+        family
+            .encode_openmetrics(
+                &mut out,
+                "requests",
+                "HTTP requests",
+                &["http"],
+                [("service", "api")].into_iter(),
+            )
+            .unwrap();
+        assert!(out.contains(r#"http_requests_total{service="api",method="GET",status="200"} 10"#));
+
+        // Binary schema + values
+        let mut schema = Schema::default();
+        family.encode_schema(&mut schema, "requests", "HTTP requests", &["http"], &[]);
+        assert_eq!(schema.items.len(), 2);
+
+        let mut values = Values::default();
+        family.encode_values(&mut values);
+        assert_eq!(values.items.len(), 2);
+    }
+}

--- a/src/iterable.rs
+++ b/src/iterable.rs
@@ -11,14 +11,22 @@ use std::fmt;
 /// [`MetricsGroup`]: ::iroh_metrics::MetricsGroup
 pub use iroh_metrics_derive::Iterable;
 
-use crate::MetricItem;
+use crate::{FamilyItem, MetricItem};
 
 /// Trait for iterating over the fields of a struct.
 pub trait Iterable {
-    /// Returns the number of fields in the struct.
+    /// Returns the number of metric fields in the struct.
     fn field_count(&self) -> usize;
     /// Returns the field name and dyn reference to the field.
     fn field_ref(&self, n: usize) -> Option<MetricItem<'_>>;
+    /// Returns the number of Family fields in the struct.
+    fn family_count(&self) -> usize {
+        0
+    }
+    /// Returns the Family field at the given index.
+    fn family_ref(&self, _n: usize) -> Option<FamilyItem<'_>> {
+        None
+    }
 }
 
 /// Helper trait to convert from `self` to `dyn Iterable`.
@@ -26,9 +34,14 @@ pub trait IntoIterable {
     /// Returns `self` as `dyn Iterable`
     fn as_iterable(&self) -> &dyn Iterable;
 
-    /// Returns an iterator over the fields of the struct.
+    /// Returns an iterator over the metric fields of the struct.
     fn field_iter(&self) -> FieldIter<'_> {
         FieldIter::new(self.as_iterable())
+    }
+
+    /// Returns an iterator over the Family fields of the struct.
+    fn family_iter(&self) -> FamilyIter<'_> {
+        FamilyIter::new(self.as_iterable())
     }
 }
 
@@ -75,6 +88,43 @@ impl<'a> Iterator for FieldIter<'a> {
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         let n = self.inner.field_count() - self.pos;
+        (n, Some(n))
+    }
+}
+
+/// Iterator over Family fields of a struct.
+pub struct FamilyIter<'a> {
+    pos: usize,
+    inner: &'a dyn Iterable,
+}
+
+impl fmt::Debug for FamilyIter<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "FamilyIter")
+    }
+}
+
+impl<'a> FamilyIter<'a> {
+    pub(crate) fn new(inner: &'a dyn Iterable) -> Self {
+        Self { pos: 0, inner }
+    }
+}
+
+impl<'a> Iterator for FamilyIter<'a> {
+    type Item = FamilyItem<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.pos == self.inner.family_count() {
+            None
+        } else {
+            let out = self.inner.family_ref(self.pos);
+            self.pos += 1;
+            out
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let n = self.inner.family_count() - self.pos;
         (n, Some(n))
     }
 }

--- a/src/iterable.rs
+++ b/src/iterable.rs
@@ -16,15 +16,15 @@ use crate::{FamilyItem, MetricItem};
 /// Trait for iterating over the fields of a struct.
 pub trait Iterable {
     /// Returns the number of metric fields in the struct.
-    fn field_count(&self) -> usize;
-    /// Returns the field name and dyn reference to the field.
-    fn field_ref(&self, n: usize) -> Option<MetricItem<'_>>;
-    /// Returns the number of Family fields in the struct.
-    fn family_count(&self) -> usize {
+    fn metric_field_count(&self) -> usize;
+    /// Returns the metric field at the given index.
+    fn metric_field_ref(&self, n: usize) -> Option<MetricItem<'_>>;
+    /// Returns the number of [`Family`](crate::Family) fields in the struct.
+    fn family_field_count(&self) -> usize {
         0
     }
-    /// Returns the Family field at the given index.
-    fn family_ref(&self, _n: usize) -> Option<FamilyItem<'_>> {
+    /// Returns the [`Family`](crate::Family) field at the given index.
+    fn family_field_ref(&self, _n: usize) -> Option<FamilyItem<'_>> {
         None
     }
 }
@@ -77,17 +77,17 @@ impl<'a> Iterator for FieldIter<'a> {
     type Item = MetricItem<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.pos == self.inner.field_count() {
+        if self.pos == self.inner.metric_field_count() {
             None
         } else {
-            let out = self.inner.field_ref(self.pos);
+            let out = self.inner.metric_field_ref(self.pos);
             self.pos += 1;
             out
         }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let n = self.inner.field_count() - self.pos;
+        let n = self.inner.metric_field_count() - self.pos;
         (n, Some(n))
     }
 }
@@ -114,17 +114,17 @@ impl<'a> Iterator for FamilyIter<'a> {
     type Item = FamilyItem<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.pos == self.inner.family_count() {
+        if self.pos == self.inner.family_field_count() {
             None
         } else {
-            let out = self.inner.family_ref(self.pos);
+            let out = self.inner.family_field_ref(self.pos);
             self.pos += 1;
             out
         }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let n = self.inner.family_count() - self.pos;
+        let n = self.inner.family_field_count() - self.pos;
         (n, Some(n))
     }
 }

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -72,7 +72,7 @@ pub trait EncodeLabelSet: Hash + Eq + Clone + Send + Sync + 'static {
 }
 
 /// Empty label set for metrics that don't need labels.
-#[derive(Debug, Clone, Hash, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub struct NoLabels;
 
 impl EncodeLabelSet for NoLabels {

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -1,0 +1,101 @@
+//! Label types for metric families.
+
+use std::{borrow::Cow, hash::Hash};
+
+/// A label value that can be encoded as a string for OpenMetrics output.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LabelValue<'a> {
+    /// String value.
+    Str(Cow<'a, str>),
+    /// Signed integer.
+    Int(i64),
+    /// Unsigned integer.
+    Uint(u64),
+    /// Boolean.
+    Bool(bool),
+}
+
+impl LabelValue<'_> {
+    /// Converts to string representation for encoding.
+    pub fn as_str(&self) -> Cow<'_, str> {
+        match self {
+            LabelValue::Str(s) => Cow::Borrowed(s.as_ref()),
+            LabelValue::Int(v) => Cow::Owned(v.to_string()),
+            LabelValue::Uint(v) => Cow::Owned(v.to_string()),
+            LabelValue::Bool(v) => Cow::Borrowed(if *v { "true" } else { "false" }),
+        }
+    }
+}
+
+impl<'a> From<&'a str> for LabelValue<'a> {
+    fn from(s: &'a str) -> Self {
+        LabelValue::Str(Cow::Borrowed(s))
+    }
+}
+
+impl From<String> for LabelValue<'static> {
+    fn from(s: String) -> Self {
+        LabelValue::Str(Cow::Owned(s))
+    }
+}
+
+macro_rules! impl_from_int {
+    ($($t:ty => $variant:ident),*) => {
+        $(
+            impl From<$t> for LabelValue<'static> {
+                fn from(v: $t) -> Self {
+                    LabelValue::$variant(v as _)
+                }
+            }
+        )*
+    };
+}
+
+impl_from_int!(i64 => Int, i32 => Int, u64 => Uint, u32 => Uint, u16 => Uint);
+
+impl From<bool> for LabelValue<'static> {
+    fn from(v: bool) -> Self {
+        LabelValue::Bool(v)
+    }
+}
+
+/// A key-value label pair.
+pub type LabelPair<'a> = (&'static str, LabelValue<'a>);
+
+/// Trait for types that can be encoded as a set of labels.
+///
+/// Implement this for label structs to use with [`Family`](crate::Family).
+/// The struct must also implement `Clone + Hash + Eq + Send + Sync`.
+pub trait EncodeLabelSet: Hash + Eq + Clone + Send + Sync + 'static {
+    /// Returns the labels as key-value pairs.
+    fn encode_label_pairs(&self) -> Vec<LabelPair<'_>>;
+}
+
+/// Empty label set for metrics that don't need labels.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Default)]
+pub struct NoLabels;
+
+impl EncodeLabelSet for NoLabels {
+    fn encode_label_pairs(&self) -> Vec<LabelPair<'_>> {
+        Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_label_value_as_str() {
+        assert_eq!(LabelValue::from("hello").as_str(), "hello");
+        assert_eq!(LabelValue::from(42i64).as_str(), "42");
+        assert_eq!(LabelValue::from(42u64).as_str(), "42");
+        assert_eq!(LabelValue::from(true).as_str(), "true");
+        assert_eq!(LabelValue::from(false).as_str(), "false");
+    }
+
+    #[test]
+    fn test_no_labels() {
+        assert!(NoLabels.encode_label_pairs().is_empty());
+    }
+}

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -62,6 +62,57 @@ impl From<bool> for LabelValue<'static> {
 /// A key-value label pair.
 pub type LabelPair<'a> = (&'static str, LabelValue<'a>);
 
+/// Encodes a single field as a [`LabelValue`].
+///
+/// Implemented for the standard label-supported types so the
+/// `#[derive(EncodeLabelSet)]` macro can borrow string fields without
+/// allocating on each scrape.
+pub trait EncodeLabelValue {
+    /// Borrows or copies `self` into a [`LabelValue`].
+    fn encode_label_value(&self) -> LabelValue<'_>;
+}
+
+impl EncodeLabelValue for str {
+    fn encode_label_value(&self) -> LabelValue<'_> {
+        LabelValue::Str(Cow::Borrowed(self))
+    }
+}
+
+impl EncodeLabelValue for String {
+    fn encode_label_value(&self) -> LabelValue<'_> {
+        LabelValue::Str(Cow::Borrowed(self.as_str()))
+    }
+}
+
+impl<T: EncodeLabelValue + ?Sized> EncodeLabelValue for &T {
+    fn encode_label_value(&self) -> LabelValue<'_> {
+        T::encode_label_value(self)
+    }
+}
+
+impl EncodeLabelValue for bool {
+    fn encode_label_value(&self) -> LabelValue<'_> {
+        LabelValue::Bool(*self)
+    }
+}
+
+macro_rules! impl_encode_label_value_int {
+    ($($t:ty => $variant:ident),*) => {
+        $(
+            impl EncodeLabelValue for $t {
+                fn encode_label_value(&self) -> LabelValue<'_> {
+                    LabelValue::$variant(*self as _)
+                }
+            }
+        )*
+    };
+}
+
+impl_encode_label_value_int!(
+    i64 => Int, i32 => Int, i16 => Int, i8 => Int,
+    u64 => Uint, u32 => Uint, u16 => Uint, u8 => Uint
+);
+
 /// Trait for types that can be encoded as a set of labels.
 ///
 /// Implement this for label structs to use with [`Family`](crate::Family).
@@ -84,6 +135,7 @@ impl EncodeLabelSet for NoLabels {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::EncodeLabelSet;
 
     #[test]
     fn test_label_value_as_str() {
@@ -97,5 +149,108 @@ mod tests {
     #[test]
     fn test_no_labels() {
         assert!(NoLabels.encode_label_pairs().is_empty());
+    }
+
+    #[test]
+    fn test_encode_label_value() {
+        // Strings must borrow (no per-scrape alloc).
+        let s = String::from("hello");
+        assert!(matches!(
+            s.encode_label_value(),
+            LabelValue::Str(Cow::Borrowed("hello"))
+        ));
+        assert!(matches!(42u64.encode_label_value(), LabelValue::Uint(42)));
+        assert!(matches!((-7i32).encode_label_value(), LabelValue::Int(-7)));
+        assert!(matches!(true.encode_label_value(), LabelValue::Bool(true)));
+    }
+
+    #[test]
+    fn test_derive_encode_label_set() {
+        // Covers field types, `name`, `skip`, and the borrowed-string guarantee.
+        #[derive(Clone, Hash, PartialEq, Eq, crate::EncodeLabelSet)]
+        struct MyLabels {
+            method: String,
+            kind: &'static str,
+            #[label(name = "status_code")]
+            status: u16,
+            count: i64,
+            #[label(skip)]
+            _internal: u64,
+        }
+
+        let labels = MyLabels {
+            method: "GET".into(),
+            kind: "x",
+            status: 200,
+            count: -3,
+            _internal: 999,
+        };
+        let pairs = labels.encode_label_pairs();
+        assert_eq!(pairs.len(), 4);
+        assert_eq!(pairs[0], ("method", LabelValue::from("GET")));
+        assert_eq!(pairs[1].0, "kind");
+        assert_eq!(pairs[1].1.as_str(), "x");
+        assert_eq!(pairs[2].0, "status_code");
+        assert_eq!(pairs[2].1.as_str(), "200");
+        assert_eq!(pairs[3].1.as_str(), "-3");
+        // String label must be borrowed.
+        assert!(matches!(&pairs[0].1, LabelValue::Str(Cow::Borrowed(_))));
+    }
+
+    #[test]
+    fn test_derive_encode_label_value_enum() {
+        // Default: snake_case for variants. `#[label(name = ...)]` overrides.
+        #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, crate::EncodeLabelValue)]
+        enum Kind {
+            Ipv4,
+            Ipv6,
+            #[label(name = "loopback")]
+            Local,
+        }
+
+        // Enum-level rename_all also works.
+        #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, crate::EncodeLabelValue)]
+        #[label(rename_all = "kebab-case")]
+        enum Mode {
+            FastPath,
+            SlowPath,
+        }
+
+        assert_eq!(Kind::Ipv4.encode_label_value().as_str(), "ipv4");
+        assert_eq!(Kind::Ipv6.encode_label_value().as_str(), "ipv6");
+        assert_eq!(Kind::Local.encode_label_value().as_str(), "loopback");
+        assert_eq!(Mode::FastPath.encode_label_value().as_str(), "fast-path");
+        assert_eq!(Mode::SlowPath.encode_label_value().as_str(), "slow-path");
+    }
+
+    #[test]
+    fn test_derive_rename_all() {
+        // `rename_all` applies to fields without explicit `#[label(name)]`.
+        #[derive(Clone, Hash, PartialEq, Eq, crate::EncodeLabelSet)]
+        #[label(rename_all = "kebab-case")]
+        struct Kebab {
+            method_name: String,
+            #[label(name = "literal")]
+            status_code: u16,
+        }
+        #[derive(Clone, Hash, PartialEq, Eq, crate::EncodeLabelSet)]
+        #[label(rename_all = "PascalCase")]
+        struct Pascal {
+            api_method: String,
+        }
+
+        let kebab = Kebab {
+            method_name: "GET".into(),
+            status_code: 200,
+        };
+        let k = kebab.encode_label_pairs();
+        assert_eq!(k[0].0, "method-name");
+        assert_eq!(k[1].0, "literal");
+
+        let pascal = Pascal {
+            api_method: "POST".into(),
+        };
+        let p = pascal.encode_label_pairs();
+        assert_eq!(p[0].0, "ApiMethod");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,8 +28,14 @@ pub mod static_core;
 /// Each field becomes a label with the field name as the key.
 /// Use `#[label(name = "custom")]` to customize the label key.
 /// Use `#[label(skip)]` to exclude a field from the label set.
+/// Use `#[label(rename_all = "...")]` on the struct to rename all fields by case rule.
+///
+/// Field types must implement [`EncodeLabelValue`]. Out of the box this
+/// covers `String`, `&'static str`, the integer types, and `bool`.
 ///
 /// The struct must also derive `Clone`, `Hash`, `PartialEq`, and `Eq`.
+/// To use the label set with [`Family`], also derive `PartialOrd` and `Ord`
+/// (the encoder produces output sorted by label set).
 ///
 /// # Example
 ///
@@ -37,6 +43,7 @@ pub mod static_core;
 /// use iroh_metrics::EncodeLabelSet;
 ///
 /// #[derive(Clone, Hash, PartialEq, Eq, EncodeLabelSet)]
+/// #[label(rename_all = "kebab-case")]
 /// struct HttpLabels {
 ///     method: String,
 ///     #[label(name = "status_code")]
@@ -44,6 +51,12 @@ pub mod static_core;
 /// }
 /// ```
 pub use iroh_metrics_derive::EncodeLabelSet;
+/// Derives [`EncodeLabelValue`] for an enum with only unit variants.
+///
+/// Each variant becomes a string label; default casing is `snake_case`.
+/// Use `#[label(rename_all = "...")]` on the enum or `#[label(name = "...")]`
+/// on a variant to customize.
+pub use iroh_metrics_derive::EncodeLabelValue;
 /// Derives [`MetricsGroup`] and [`Iterable`].
 ///
 /// This derive macro only works on structs with named fields.
@@ -59,7 +72,11 @@ pub use iroh_metrics_derive::EncodeLabelSet;
 /// converted to `camel_case` will be used as the return value of the [`MetricsGroup::name`]
 /// method. The name can be customized by setting a `#[metrics(name = "my-name")]` attribute.
 ///
-/// It will also generate a [`Iterable`] impl.
+/// It will also generate a [`Iterable`] impl. Fields with the `Family<_, _>`
+/// type are routed through the family-encoder iteration. Detection inspects
+/// the last segment of the field type, so `iroh_metrics::Family<L, M>` is
+/// recognized but a type alias is not — annotate the field with
+/// `#[metrics(family)]` in that case.
 ///
 /// [`Iterable`]: iterable::Iterable
 pub use iroh_metrics_derive::MetricsGroup;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,13 @@
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![cfg_attr(iroh_docsrs, feature(doc_auto_cfg))]
 
-pub use self::{base::*, metrics::*, registry::*};
+pub use self::{base::*, family::Family, labels::*, metrics::*, registry::*};
 
 mod base;
 pub mod encoding;
+mod family;
 pub mod iterable;
+mod labels;
 mod metrics;
 mod registry;
 #[cfg(feature = "service")]
@@ -15,6 +17,27 @@ pub mod service;
 #[cfg(feature = "static_core")]
 pub mod static_core;
 
+/// Derives [`EncodeLabelSet`] for a struct.
+///
+/// Each field becomes a label with the field name as the key.
+/// Use `#[label(name = "custom")]` to customize the label key.
+/// Use `#[label(skip)]` to exclude a field from the label set.
+///
+/// The struct must also derive `Clone`, `Hash`, `PartialEq`, and `Eq`.
+///
+/// # Example
+///
+/// ```
+/// use iroh_metrics::EncodeLabelSet;
+///
+/// #[derive(Clone, Hash, PartialEq, Eq, EncodeLabelSet)]
+/// struct HttpLabels {
+///     method: String,
+///     #[label(name = "status_code")]
+///     status: u16,
+/// }
+/// ```
+pub use iroh_metrics_derive::EncodeLabelSet;
 /// Derives [`MetricsGroup`] and [`Iterable`].
 ///
 /// This derive macro only works on structs with named fields.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,9 @@ pub mod static_core;
 /// Each field becomes a label with the field name as the key.
 /// Use `#[label(name = "custom")]` to customize the label key.
 /// Use `#[label(skip)]` to exclude a field from the label set.
-/// Use `#[label(rename_all = "...")]` on the struct to rename all fields by case rule.
+/// Use `#[label(rename_all = "...")]` on the struct to rename all fields by
+/// case rule. Supported rules: `snake_case`, `camelCase`, `PascalCase`,
+/// `SCREAMING_SNAKE_CASE`, `kebab-case`, `lowercase`, `UPPERCASE`.
 ///
 /// Field types must implement [`EncodeLabelValue`]. Out of the box this
 /// covers `String`, `&'static str`, the integer types, and `bool`.
@@ -51,12 +53,15 @@ pub mod static_core;
 /// }
 /// ```
 pub use iroh_metrics_derive::EncodeLabelSet;
+
 /// Derives [`EncodeLabelValue`] for an enum with only unit variants.
 ///
 /// Each variant becomes a string label; default casing is `snake_case`.
 /// Use `#[label(rename_all = "...")]` on the enum or `#[label(name = "...")]`
-/// on a variant to customize.
+/// on a variant to customize. See [`macro@EncodeLabelSet`] for the list of
+/// supported `rename_all` values.
 pub use iroh_metrics_derive::EncodeLabelValue;
+
 /// Derives [`MetricsGroup`] and [`Iterable`].
 ///
 /// This derive macro only works on structs with named fields.
@@ -80,6 +85,7 @@ pub use iroh_metrics_derive::EncodeLabelValue;
 ///
 /// [`Iterable`]: iterable::Iterable
 pub use iroh_metrics_derive::MetricsGroup;
+
 /// Derives [`MetricsGroupSet`] for a struct.
 ///
 /// All fields of the struct must be public and have a type of `Arc<SomeType>`,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,6 @@ pub mod static_core;
 /// }
 /// ```
 pub use iroh_metrics_derive::EncodeLabelSet;
-
 /// Derives [`EncodeLabelValue`] for an enum with only unit variants.
 ///
 /// Each variant becomes a string label; default casing is `snake_case`.
@@ -61,7 +60,6 @@ pub use iroh_metrics_derive::EncodeLabelSet;
 /// on a variant to customize. See [`macro@EncodeLabelSet`] for the list of
 /// supported `rename_all` values.
 pub use iroh_metrics_derive::EncodeLabelValue;
-
 /// Derives [`MetricsGroup`] and [`Iterable`].
 ///
 /// This derive macro only works on structs with named fields.
@@ -87,7 +85,6 @@ pub use iroh_metrics_derive::EncodeLabelValue;
 /// [`Iterable::metric_field_ref`]: iterable::Iterable::metric_field_ref
 /// [`Iterable::family_field_ref`]: iterable::Iterable::family_field_ref
 pub use iroh_metrics_derive::MetricsGroup;
-
 /// Derives [`MetricsGroupSet`] for a struct.
 ///
 /// All fields of the struct must be public and have a type of `Arc<SomeType>`,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,12 +78,14 @@ pub use iroh_metrics_derive::EncodeLabelValue;
 /// method. The name can be customized by setting a `#[metrics(name = "my-name")]` attribute.
 ///
 /// It will also generate a [`Iterable`] impl. Fields with the `Family<_, _>`
-/// type are routed through the family-encoder iteration. Detection inspects
-/// the last segment of the field type, so `iroh_metrics::Family<L, M>` is
-/// recognized but a type alias is not — annotate the field with
-/// `#[metrics(family)]` in that case.
+/// type are routed through [`Iterable::family_field_ref`] instead of
+/// [`Iterable::metric_field_ref`]. Detection inspects the last segment of
+/// the field type, so `iroh_metrics::Family<L, M>` is recognized but a type
+/// alias is not — annotate the field with `#[metrics(family)]` in that case.
 ///
 /// [`Iterable`]: iterable::Iterable
+/// [`Iterable::metric_field_ref`]: iterable::Iterable::metric_field_ref
+/// [`Iterable::family_field_ref`]: iterable::Iterable::family_field_ref
 pub use iroh_metrics_derive::MetricsGroup;
 
 /// Derives [`MetricsGroupSet`] for a struct.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,10 @@
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![cfg_attr(iroh_docsrs, feature(doc_auto_cfg))]
 
-pub use self::{base::*, family::Family, labels::*, metrics::*, registry::*};
+pub use self::{
+    base::*, family::Family, family::FamilyEncoder, family::FamilyItem, labels::*, metrics::*,
+    registry::*,
+};
 
 mod base;
 pub mod encoding;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,10 @@
 #![cfg_attr(iroh_docsrs, feature(doc_auto_cfg))]
 
 pub use self::{
-    base::*, family::Family, family::FamilyEncoder, family::FamilyItem, labels::*, metrics::*,
+    base::*,
+    family::{Family, FamilyEncoder, FamilyItem},
+    labels::*,
+    metrics::*,
     registry::*,
 };
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -83,18 +83,28 @@ impl Metric for MetricValue {
         self.clone()
     }
 
+    fn set_value(&self, _value: MetricValue) {
+        // MetricValue is immutable, this is a no-op
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }
 }
 
 /// Trait for metric items.
-pub trait Metric: std::fmt::Debug {
+pub trait Metric: std::fmt::Debug + Send + Sync {
     /// Returns the type of this metric.
     fn r#type(&self) -> MetricType;
 
     /// Returns the current value of this metric.
     fn value(&self) -> MetricValue;
+
+    /// Sets the value of this metric from a [`MetricValue`].
+    ///
+    /// This is used for deserialization. If the value type doesn't match,
+    /// the implementation should silently ignore the value.
+    fn set_value(&self, value: MetricValue);
 
     /// Casts this metric to [`Any`] for downcasting to concrete types.
     fn as_any(&self) -> &dyn Any;
@@ -117,6 +127,12 @@ impl Metric for Counter {
 
     fn r#type(&self) -> MetricType {
         MetricType::Counter
+    }
+
+    fn set_value(&self, value: MetricValue) {
+        if let MetricValue::Counter(v) = value {
+            self.set(v);
+        }
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -346,6 +362,41 @@ impl Metric for Histogram {
         }
     }
 
+    fn set_value(&self, value: MetricValue) {
+        #[cfg(feature = "metrics")]
+        if let MetricValue::Histogram {
+            buckets,
+            sum,
+            count,
+        } = value
+        {
+            // Only set if bucket count matches
+            if buckets.len() != self.buckets.len() {
+                return;
+            }
+
+            // Validate cumulative counts are monotonically increasing
+            for i in 1..buckets.len() {
+                if buckets[i].1 < buckets[i - 1].1 {
+                    return;
+                }
+            }
+
+            self.count.store(count, Ordering::Relaxed);
+            self.sum.store(sum.to_bits(), Ordering::Relaxed);
+
+            // Convert cumulative counts back to individual bucket counts
+            for (i, (_, cumulative)) in buckets.iter().enumerate() {
+                let prev = if i > 0 { buckets[i - 1].1 } else { 0 };
+                self.counts[i].store(cumulative - prev, Ordering::Relaxed);
+            }
+        }
+        #[cfg(not(feature = "metrics"))]
+        {
+            let _ = value;
+        }
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -358,6 +409,12 @@ impl Metric for Gauge {
 
     fn value(&self) -> MetricValue {
         MetricValue::Gauge(self.get())
+    }
+
+    fn set_value(&self, value: MetricValue) {
+        if let MetricValue::Gauge(v) = value {
+            self.set(v);
+        }
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -102,8 +102,12 @@ pub trait Metric: std::fmt::Debug + Send + Sync {
 
     /// Sets the value of this metric from a [`MetricValue`].
     ///
-    /// This is used for deserialization. If the value type doesn't match,
-    /// the implementation should silently ignore the value.
+    /// Used by the [`Family`](crate::Family) deserialize impl: a family
+    /// stores generic `Arc<M>` entries and round-trips through serde as
+    /// `Vec<(L, MetricValue)>`, so on deserialize each `M` is constructed via
+    /// `Default` and then populated through this setter. If the variant
+    /// doesn't match this metric's type the implementation must silently
+    /// ignore it.
     fn set_value(&self, value: MetricValue);
 
     /// Casts this metric to [`Any`] for downcasting to concrete types.

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -9,7 +9,7 @@ use std::{
 
 use portable_atomic::{AtomicU64, Ordering};
 
-use crate::{Error, MetricsGroup, MetricsGroupSet, encoding::encode_eof};
+use crate::{Error, MetricsGroup, MetricsGroupSet, encoding::encode_eof, iterable::IntoIterable};
 
 /// A registry for [`MetricsGroup`].
 #[derive(Debug, Default)]
@@ -74,6 +74,9 @@ impl Registry {
     /// Registers a [`MetricsGroup`] into this registry.
     pub fn register(&mut self, metrics_group: Arc<dyn MetricsGroup>) {
         self.schema_version.fetch_add(1, Ordering::Relaxed);
+        for family in IntoIterable::family_iter(&*metrics_group) {
+            family.attach_schema_version(Arc::clone(&self.schema_version));
+        }
         self.metrics.push(metrics_group);
     }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -9,7 +9,7 @@ use std::{
 
 use portable_atomic::{AtomicU64, Ordering};
 
-use crate::{Error, MetricsGroup, MetricsGroupSet, encoding::write_eof};
+use crate::{Error, MetricsGroup, MetricsGroupSet, encoding::encode_eof};
 
 /// A registry for [`MetricsGroup`].
 #[derive(Debug, Default)]
@@ -156,7 +156,7 @@ pub trait MetricsSource: Send + 'static {
 impl MetricsSource for Registry {
     fn encode_openmetrics(&self, writer: &mut impl std::fmt::Write) -> Result<(), Error> {
         self.encode_openmetrics_to_writer(writer)?;
-        write_eof(writer)?;
+        encode_eof(writer)?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Description
Adds first-class support for labeled metrics via a `Family<L, M>` type, an `EncodeLabelSet`/`EncodeLabelValue` trait pair, and matching derive macros.

Example of usage in iroh:
```rust
use std::sync::Arc;
use iroh_metrics::{Counter, EncodeLabelSet, EncodeLabelValue, Family, MetricsGroup};

#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, EncodeLabelValue)]
enum Transport { Ipv4, Ipv6, Relay }

#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord, EncodeLabelSet)]
pub struct ConnectionLabels {
    pub transport: Transport,
}

#[derive(Debug, Default, MetricsGroup)]
#[metrics(name = "relayserver")]
pub struct Metrics {
    pub bytes_sent: Counter,
    pub bytes_recv: Counter,
    pub bytes_by_conn: Family<ConnectionLabels, Counter>,
}

fn handle_send(metrics: &Metrics, transport: Transport, data: &[u8]) {
    metrics.bytes_sent.inc_by(data.len() as u64);
    metrics
        .bytes_by_conn
        .get_or_create(&ConnectionLabels { transport })
        .inc_by(data.len() as u64);
}
```

## Breaking Changes

API surface:
- `Iterable` trait methods renamed: `field_count`/`field_ref` → `metric_field_count`/`metric_field_ref`, plus new `family_field_count`/`family_field_ref`. Hand-written `impl Iterable for Foo` must update; users of `#[derive(MetricsGroup)]`/`#[derive(Iterable)]` get the rename automatically when they update `iroh-metrics-derive`.
- `Metric` trait now requires `Send + Sync` (needed by `Family<L, M>` to share metrics across threads) and gains a `set_value(&self, MetricValue)` hook (used by the family deserialize path). Custom `impl Metric` blocks must add the bounds and the new method.
- `MetricsSource for Decoder` now de-duplicates `# HELP`/`# TYPE` headers across consecutive same-name items so that family rows print once like the registry path does. Bug fix in practice; behavioural change worth flagging.

Internal/encoding helpers (only relevant if you depended on the previously-`pub(crate)`-or-not boundary in `iroh_metrics::encoding`):
- `Item::encode_openmetrics` documents that callers iterating items themselves should prefer `MetricsSource::encode_openmetrics` on the `Decoder`.
- `ItemSchema` gained a new `from_label_iter` constructor (additive).

New (additive — not breaking):
- `Family<L, M>`, `FamilyEncoder`, `FamilyItem`.
- `EncodeLabelSet`, `EncodeLabelValue`, `LabelValue`, `LabelPair`, `NoLabels`.
- `#[derive(EncodeLabelSet)]`, `#[derive(EncodeLabelValue)]` (with `#[label(name)]`, `#[label(skip)]`, `#[label(rename_all)]`).
- `#[metrics(family)]` field-level override on `MetricsGroup`/`Iterable` derive for type-aliased `Family`.

## Notes & open questions

- OpenMetrics text output now escapes `\`, `"`, `\n` in label values and `\`, `\n` in HELP text per spec.
- `Encoder::export` retries the walk if a concurrent `Family::get_or_create` bumps the schema version mid-export, so the returned `(schema, values)` are always internally consistent.
- Counter `_total` suffix is no longer doubled if the user names a metric `*_total` already.
- `Family<L, M>` caches the rendered label strings per entry to avoid re-encoding label pairs on every scrape.

## Change checklist
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.