### PR TITLE
refactor!: expose the services as structs that abort on drop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
 name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
@@ -531,6 +549,7 @@ dependencies = [
  "ryu",
  "serde",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 
@@ -1216,6 +1235,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,9 +206,9 @@ checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -238,6 +238,7 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1092,6 +1093,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,8 @@ hyper-util = { version = "0.1.17", features = ["tokio"], optional = true }
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-no-provider"], optional = true }
 rustls = { version = "0.23", default-features = false, features = ["ring"], optional = true }
 rustls-platform-verifier = { version = "0.7", optional = true }
-tokio = { version = "1", features = ["rt", "net", "fs"], optional = true }
+tokio = { version = "1", features = ["rt", "net", "fs", "macros"], optional = true }
+tokio-util = { version = "0.7", features = ["rt"], optional = true }
 postcard = { version = "1.1.1", features = ["use-std"] }
 
 [dev-dependencies]
@@ -73,6 +74,7 @@ service = [
     "dep:rustls",
     "dep:rustls-platform-verifier",
     "dep:tokio",
+    "dep:tokio-util",
 ]
 # Enables a global, static metrics collector
 static_core = ["metrics", "dep:erased_set"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ reqwest = { version = "0.13", default-features = false, features = ["json", "rus
 rustls = { version = "0.23", default-features = false, features = ["ring"], optional = true }
 rustls-platform-verifier = { version = "0.7", optional = true }
 tokio = { version = "1", features = ["rt", "net", "fs", "macros"], optional = true }
-tokio-util = { version = "0.7", features = ["rt"], optional = true }
+tokio-util = { version = "0.7.18", features = ["rt"], optional = true }
 postcard = { version = "1.1.1", features = ["use-std"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ hyper-util = { version = "0.1.17", features = ["tokio"], optional = true }
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-no-provider"], optional = true }
 rustls = { version = "0.23", default-features = false, features = ["ring"], optional = true }
 rustls-platform-verifier = { version = "0.7", optional = true }
-tokio = { version = "1", features = ["rt", "net", "fs", "macros"], optional = true }
+tokio = { version = "1.47", features = ["rt", "net", "fs", "macros"], optional = true }
 tokio-util = { version = "0.7.18", features = ["rt"], optional = true }
 postcard = { version = "1.1.1", features = ["use-std"] }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -36,9 +36,9 @@ impl MetricsServer {
         addr: SocketAddr,
         registry: impl MetricsSource + Clone,
     ) -> std::io::Result<Self> {
-        info!("Starting metrics server on {addr}");
         let listener = TcpListener::bind(addr).await?;
         let addr = listener.local_addr()?;
+        info!("Starting metrics server on {addr}");
         let cancel = CancellationToken::new();
         let task = tokio::spawn(server_loop(listener, registry, cancel.clone()));
         Ok(Self {
@@ -217,7 +217,7 @@ pub struct MetricsPushExporter {
 
 impl MetricsPushExporter {
     /// Spawns the push exporter in a background task.
-    pub fn spawn(cfg: MetricsExporterConfig, registry: impl MetricsSource) -> Self {
+    pub async fn spawn(cfg: MetricsExporterConfig, registry: impl MetricsSource) -> Self {
         let cancel = CancellationToken::new();
         let task = tokio::spawn(exporter_loop(cfg, registry, cancel.clone()));
         Self {
@@ -534,7 +534,7 @@ mod tests {
             tls_config: None,
         };
 
-        let exporter = MetricsPushExporter::spawn(cfg, registry());
+        let exporter = MetricsPushExporter::spawn(cfg, registry()).await;
 
         let (path, body) = tokio::time::timeout(Duration::from_secs(5), rx)
             .await

--- a/src/service.rs
+++ b/src/service.rs
@@ -25,6 +25,7 @@ type BytesBody = http_body_util::Full<hyper::body::Bytes>;
 /// [`shutdown`](Self::shutdown).
 #[derive(Debug)]
 pub struct MetricsServer {
+    addr: SocketAddr,
     cancel: CancellationToken,
     task: AbortOnDropHandle<()>,
 }
@@ -37,12 +38,19 @@ impl MetricsServer {
     ) -> std::io::Result<Self> {
         info!("Starting metrics server on {addr}");
         let listener = TcpListener::bind(addr).await?;
+        let addr = listener.local_addr()?;
         let cancel = CancellationToken::new();
         let task = tokio::spawn(server_loop(listener, registry, cancel.clone()));
         Ok(Self {
+            addr,
             cancel,
             task: AbortOnDropHandle::new(task),
         })
+    }
+
+    /// Returns the local address the server is bound to.
+    pub fn local_addr(&self) -> SocketAddr {
+        self.addr
     }
 
     /// Gracefully shuts down the server.
@@ -121,10 +129,12 @@ async fn serve_connection(
 
 /// Periodic dumper that writes metrics as CSV rows to a file.
 ///
-/// Aborts the background task on drop.
+/// Aborts the background task on drop. For an orderly shutdown that lets
+/// the in-flight dump finish, call [`shutdown`](Self::shutdown).
 #[derive(Debug)]
 pub struct MetricsDumper {
-    _task: AbortOnDropHandle<()>,
+    cancel: CancellationToken,
+    task: AbortOnDropHandle<()>,
 }
 
 impl MetricsDumper {
@@ -143,53 +153,100 @@ impl MetricsDumper {
             .truncate(true)
             .open(&path)
             .await?;
-        let task = tokio::spawn(async move {
-            let mut file = tokio::io::BufWriter::new(file);
-            let start = Instant::now();
-            let mut write_header = true;
-            loop {
-                let encoded = match registry.encode_openmetrics_to_string() {
-                    Ok(s) => s,
-                    Err(err) => {
-                        error!("metrics dumper failed: {err:#}");
-                        return;
-                    }
-                };
-                if let Err(err) = dump_metrics(&mut file, &start, &encoded, write_header).await {
-                    error!("metrics dumper failed: {err:#}");
-                    return;
-                }
-                if !write_header {
-                    tokio::time::sleep(interval).await;
-                }
-                write_header = false;
-            }
-        });
+        let cancel = CancellationToken::new();
+        let task = tokio::spawn(dumper_loop(
+            tokio::io::BufWriter::new(file),
+            interval,
+            registry,
+            cancel.clone(),
+        ));
         Ok(Self {
-            _task: AbortOnDropHandle::new(task),
+            cancel,
+            task: AbortOnDropHandle::new(task),
         })
+    }
+
+    /// Gracefully shuts down the dumper.
+    ///
+    /// Stops between dump cycles, letting the current dump finish before
+    /// returning.
+    pub async fn shutdown(self) {
+        self.cancel.cancel();
+        let _ = self.task.await;
+    }
+}
+
+async fn dumper_loop(
+    mut file: tokio::io::BufWriter<tokio::fs::File>,
+    interval: Duration,
+    registry: impl MetricsSource,
+    cancel: CancellationToken,
+) {
+    let start = Instant::now();
+    let mut write_header = true;
+    loop {
+        let encoded = match registry.encode_openmetrics_to_string() {
+            Ok(s) => s,
+            Err(err) => {
+                error!("metrics dumper failed: {err:#}");
+                return;
+            }
+        };
+        if let Err(err) = dump_metrics(&mut file, &start, &encoded, write_header).await {
+            error!("metrics dumper failed: {err:#}");
+            return;
+        }
+        if write_header {
+            write_header = false;
+            if cancel.is_cancelled() {
+                break;
+            }
+        } else {
+            tokio::select! {
+                biased;
+                () = cancel.cancelled() => break,
+                () = tokio::time::sleep(interval) => {}
+            }
+        }
     }
 }
 
 /// Periodic exporter that pushes metrics to a Prometheus push gateway.
 ///
-/// Aborts the background task on drop.
+/// Aborts the background task on drop. For an orderly shutdown that lets
+/// the in-flight push finish, call [`shutdown`](Self::shutdown).
 #[derive(Debug)]
 pub struct MetricsPushExporter {
-    _task: AbortOnDropHandle<()>,
+    cancel: CancellationToken,
+    task: AbortOnDropHandle<()>,
 }
 
 impl MetricsPushExporter {
     /// Spawns the push exporter in a background task.
     pub fn spawn(cfg: MetricsExporterConfig, registry: impl MetricsSource) -> Self {
-        let task = tokio::spawn(exporter_loop(cfg, registry));
+        let cancel = CancellationToken::new();
+        let task = tokio::spawn(exporter_loop(cfg, registry, cancel.clone()));
         Self {
-            _task: AbortOnDropHandle::new(task),
+            cancel,
+            task: AbortOnDropHandle::new(task),
         }
+    }
+
+    /// Gracefully shuts down the exporter.
+    ///
+    /// Stops between push cycles, letting the current push finish before
+    /// returning.
+    pub async fn shutdown(self) {
+        self.cancel.cancel();
+        let _ = self.task.await;
     }
 }
 
-async fn exporter_loop(cfg: MetricsExporterConfig, registry: impl MetricsSource) {
+async fn exporter_loop(
+    cfg: MetricsExporterConfig,
+    registry: impl MetricsSource,
+    cancel: CancellationToken,
+) {
     let MetricsExporterConfig {
         interval,
         endpoint,
@@ -197,28 +254,23 @@ async fn exporter_loop(cfg: MetricsExporterConfig, registry: impl MetricsSource)
         instance_name,
         username,
         password,
+        tls_config,
     } = cfg;
 
-    // All of the `.expect`s were previously internal to the `reqwest::Client::new` call.
-    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let tls = tls_config.unwrap_or_else(default_tls_config);
     let push_client = reqwest::Client::builder()
-        .use_preconfigured_tls(
-            rustls::ClientConfig::builder_with_provider(provider.clone())
-                .with_safe_default_protocol_versions()
-                .expect("no TLS 1.3 support in ring")
-                .dangerous()
-                .with_custom_certificate_verifier(Arc::new(
-                    rustls_platform_verifier::Verifier::new(provider)
-                        .expect("rustls platform verifier incompatible with ring"),
-                )),
-        )
+        .use_preconfigured_tls(tls)
         .build()
-        .expect("reqwest incompatible with ring");
+        .expect("reqwest client builder failed");
 
     let prom_gateway_uri =
         format!("{endpoint}/metrics/job/{service_name}/instance/{instance_name}");
     loop {
-        tokio::time::sleep(interval).await;
+        tokio::select! {
+            biased;
+            () = cancel.cancelled() => break,
+            () = tokio::time::sleep(interval) => {}
+        }
         let buf = match registry.encode_openmetrics_to_string() {
             Ok(buf) => buf,
             Err(err) => {
@@ -248,6 +300,21 @@ async fn exporter_loop(cfg: MetricsExporterConfig, registry: impl MetricsSource)
             }
         }
     }
+}
+
+/// Builds the default rustls config used when no [`MetricsExporterConfig::tls_config`]
+/// is supplied: the ring crypto provider with the platform certificate verifier.
+fn default_tls_config() -> rustls::ClientConfig {
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    rustls::ClientConfig::builder_with_provider(provider.clone())
+        .with_safe_default_protocol_versions()
+        .expect("no TLS 1.3 support in ring")
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(
+            rustls_platform_verifier::Verifier::new(provider)
+                .expect("rustls platform verifier incompatible with ring"),
+        ))
+        .with_no_client_auth()
 }
 
 /// HTTP handler that responds with the OpenMetrics encoding of the metrics.
@@ -309,7 +376,7 @@ async fn dump_metrics(
 }
 
 /// Configuration for pushing metrics to a remote endpoint.
-#[derive(PartialEq, Eq, Debug, Default, serde::Deserialize, Clone)]
+#[derive(Debug, Default, serde::Deserialize, Clone)]
 pub struct MetricsExporterConfig {
     /// The push interval.
     pub interval: Duration,
@@ -336,4 +403,146 @@ pub struct MetricsExporterConfig {
     pub username: Option<String>,
     /// The password for basic auth for the push metrics collector.
     pub password: String,
+    /// Custom rustls [`ClientConfig`] for the push client.
+    ///
+    /// If `None`, a default config is used: the ring crypto provider with
+    /// the platform certificate verifier.
+    ///
+    /// [`ClientConfig`]: rustls::ClientConfig
+    #[serde(skip)]
+    pub tls_config: Option<rustls::ClientConfig>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use super::*;
+    use crate::{Counter, Registry};
+
+    #[derive(Debug, crate::MetricsGroup)]
+    #[metrics(default, name = "test")]
+    struct TestMetrics {
+        /// Smoke test counter
+        count: Counter,
+    }
+
+    fn registry() -> Arc<Registry> {
+        let metrics = Arc::new(TestMetrics::default());
+        metrics.count.inc_by(7);
+        let mut reg = Registry::default();
+        reg.register(metrics);
+        Arc::new(reg)
+    }
+
+    #[tokio::test]
+    async fn smoke_metrics_server() {
+        let server = MetricsServer::spawn("127.0.0.1:0".parse().unwrap(), registry())
+            .await
+            .unwrap();
+        let addr = server.local_addr();
+
+        let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+        stream
+            .write_all(b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+            .await
+            .unwrap();
+        let mut response = Vec::new();
+        stream.read_to_end(&mut response).await.unwrap();
+        let response = String::from_utf8(response).unwrap();
+
+        assert!(response.starts_with("HTTP/1.1 200"), "response: {response}");
+        assert!(
+            response.contains("test_count_total 7"),
+            "response: {response}"
+        );
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn smoke_metrics_dumper() {
+        let path = std::env::temp_dir().join(format!(
+            "iroh-metrics-smoke-dumper-{}.csv",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+
+        let dumper = MetricsDumper::spawn(path.clone(), Duration::from_millis(50), registry())
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        dumper.shutdown().await;
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let _ = std::fs::remove_file(&path);
+
+        let mut lines = contents.lines();
+        let header = lines.next().expect("header line");
+        assert!(header.starts_with("time"), "header: {header}");
+        assert!(header.contains("test_count"), "header: {header}");
+        let row = lines.next().expect("at least one data row");
+        assert!(row.contains("7.000"), "row: {row}");
+    }
+
+    #[tokio::test]
+    async fn smoke_metrics_push_exporter() {
+        use std::sync::Mutex;
+
+        use http_body_util::{BodyExt, Full};
+        use hyper::{Request, Response, body::Incoming, service::service_fn};
+        use hyper_util::rt::TokioIo;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx) = tokio::sync::oneshot::channel::<(String, String)>();
+        let tx = Arc::new(Mutex::new(Some(tx)));
+
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let io = TokioIo::new(stream);
+            let service = service_fn(move |req: Request<Incoming>| {
+                let tx = tx.clone();
+                async move {
+                    let path = req.uri().path().to_string();
+                    let body = req.into_body().collect().await.unwrap().to_bytes();
+                    let body = String::from_utf8_lossy(&body).to_string();
+                    if let Some(tx) = tx.lock().expect("poisoned").take() {
+                        let _ = tx.send((path, body));
+                    }
+                    Ok::<_, std::convert::Infallible>(Response::new(Full::new(
+                        hyper::body::Bytes::new(),
+                    )))
+                }
+            });
+            let _ = hyper::server::conn::http1::Builder::new()
+                .serve_connection(io, service)
+                .await;
+        });
+
+        let cfg = MetricsExporterConfig {
+            interval: Duration::from_millis(50),
+            endpoint: format!("http://{addr}"),
+            service_name: "svc".to_string(),
+            instance_name: "inst".to_string(),
+            username: None,
+            password: String::new(),
+            tls_config: None,
+        };
+
+        let exporter = MetricsPushExporter::spawn(cfg, registry());
+
+        let (path, body) = tokio::time::timeout(Duration::from_secs(5), rx)
+            .await
+            .expect("timeout waiting for push")
+            .expect("oneshot dropped");
+
+        assert_eq!(path, "/metrics/job/svc/instance/inst");
+        assert!(body.contains("test_count_total 7"), "body: {body}");
+
+        exporter.shutdown().await;
+    }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -217,6 +217,7 @@ pub struct MetricsPushExporter {
 
 impl MetricsPushExporter {
     /// Spawns the push exporter in a background task.
+    #[allow(clippy::unused_async)]
     pub async fn spawn(cfg: MetricsExporterConfig, registry: impl MetricsSource) -> Self {
         let cancel = CancellationToken::new();
         let task = tokio::spawn(exporter_loop(cfg, registry, cancel.clone()));

--- a/src/service.rs
+++ b/src/service.rs
@@ -196,17 +196,11 @@ async fn dumper_loop(
             error!("metrics dumper failed: {err:#}");
             return;
         }
-        if write_header {
-            write_header = false;
-            if cancel.is_cancelled() {
-                break;
-            }
-        } else {
-            tokio::select! {
-                biased;
-                () = cancel.cancelled() => break,
-                () = tokio::time::sleep(interval) => {}
-            }
+        write_header = false;
+        tokio::select! {
+            biased;
+            () = cancel.cancelled() => break,
+            () = tokio::time::sleep(interval) => {}
         }
     }
 }
@@ -235,7 +229,7 @@ impl MetricsPushExporter {
     /// Gracefully shuts down the exporter.
     ///
     /// Stops between push cycles, letting the current push finish before
-    /// returning.
+    /// returning. Wrap in [`tokio::time::timeout`] to bound the wait.
     pub async fn shutdown(self) {
         self.cancel.cancel();
         let _ = self.task.await;
@@ -271,6 +265,7 @@ async fn exporter_loop(
             () = cancel.cancelled() => break,
             () = tokio::time::sleep(interval) => {}
         }
+
         let buf = match registry.encode_openmetrics_to_string() {
             Ok(buf) => buf,
             Err(err) => {
@@ -294,9 +289,15 @@ async fn exporter_loop(
                 debug!("pushed metrics to gateway");
             }
             _ => {
-                warn!("failed to push metrics to gateway: {:?}", res);
-                let body = res.text().await.unwrap();
-                warn!("error body: {}", body);
+                let status = res.status();
+                match res.text().await {
+                    Ok(body) => warn!("failed to push metrics to gateway: {status} {body}"),
+                    Err(err) => {
+                        warn!(
+                            "failed to push metrics to gateway: {status}; reading body failed: {err:#}"
+                        )
+                    }
+                }
             }
         }
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,4 +1,7 @@
-//! Functions to start services that deal with metrics exposed by this crate.
+//! Background services that expose or forward metrics from this crate.
+//!
+//! Each service runs in a single background task that is aborted when the
+//! returned handle is dropped.
 
 use std::{
     net::SocketAddr,
@@ -7,68 +10,186 @@ use std::{
 };
 
 use hyper::{Request, Response, service::service_fn};
-use tokio::{io::AsyncWriteExt as _, net::TcpListener};
+use tokio::{io::AsyncWriteExt as _, net::TcpListener, task::JoinSet};
+use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
 use tracing::{debug, error, info, warn};
 
 use crate::{Error, MetricsSource, parse_prometheus_metrics};
 
 type BytesBody = http_body_util::Full<hyper::body::Bytes>;
 
-/// Start a HTTP server to expose metrics .
-pub async fn start_metrics_server(
-    addr: SocketAddr,
-    registry: impl MetricsSource + Clone,
-) -> std::io::Result<()> {
-    info!("Starting metrics server on {addr}");
-    let listener = TcpListener::bind(addr).await?;
+/// HTTP server that exposes metrics in the OpenMetrics text format.
+///
+/// Aborts the accept loop and all in-flight connections on drop. For an
+/// orderly shutdown that lets in-flight connections finish, call
+/// [`shutdown`](Self::shutdown).
+#[derive(Debug)]
+pub struct MetricsServer {
+    cancel: CancellationToken,
+    task: AbortOnDropHandle<()>,
+}
 
+impl MetricsServer {
+    /// Binds to `addr` and spawns the server in a background task.
+    pub async fn spawn(
+        addr: SocketAddr,
+        registry: impl MetricsSource + Clone,
+    ) -> std::io::Result<Self> {
+        info!("Starting metrics server on {addr}");
+        let listener = TcpListener::bind(addr).await?;
+        let cancel = CancellationToken::new();
+        let task = tokio::spawn(server_loop(listener, registry, cancel.clone()));
+        Ok(Self {
+            cancel,
+            task: AbortOnDropHandle::new(task),
+        })
+    }
+
+    /// Gracefully shuts down the server.
+    ///
+    /// Stops accepting new connections, signals in-flight connections to wind
+    /// down, and waits for them to finish. Wrap in [`tokio::time::timeout`]
+    /// to bound the wait.
+    pub async fn shutdown(self) {
+        self.cancel.cancel();
+        let _ = self.task.await;
+    }
+}
+
+async fn server_loop(
+    listener: TcpListener,
+    registry: impl MetricsSource + Clone,
+    cancel: CancellationToken,
+) {
+    let mut tasks: JoinSet<()> = JoinSet::new();
     loop {
-        let (stream, _addr) = listener.accept().await?;
-        let io = hyper_util::rt::TokioIo::new(stream);
-        let registry = registry.clone();
-        tokio::spawn(async move {
-            if let Err(err) = hyper::server::conn::http1::Builder::new()
-                .serve_connection(io, service_fn(move |req| handler(req, registry.clone())))
-                .await
-            {
+        tokio::select! {
+            biased;
+            () = cancel.cancelled() => break,
+            res = listener.accept() => {
+                match res {
+                    Ok((stream, _addr)) => {
+                        tasks.spawn(serve_connection(stream, registry.clone(), cancel.clone()));
+                    }
+                    Err(err) => {
+                        error!("metrics server accept failed: {err:#}");
+                        break;
+                    }
+                }
+            }
+            Some(res) = tasks.join_next(), if !tasks.is_empty() => {
+                if let Err(err) = res {
+                    if !err.is_cancelled() {
+                        debug!("metrics connection task failed: {err:#}");
+                    }
+                }
+            }
+        }
+    }
+    while let Some(res) = tasks.join_next().await {
+        if let Err(err) = res {
+            if !err.is_cancelled() {
+                debug!("metrics connection task failed: {err:#}");
+            }
+        }
+    }
+}
+
+async fn serve_connection(
+    stream: tokio::net::TcpStream,
+    registry: impl MetricsSource + Clone,
+    cancel: CancellationToken,
+) {
+    let io = hyper_util::rt::TokioIo::new(stream);
+    let conn = hyper::server::conn::http1::Builder::new()
+        .serve_connection(io, service_fn(move |req| handler(req, registry.clone())));
+    let mut conn = std::pin::pin!(conn);
+    tokio::select! {
+        res = conn.as_mut() => {
+            if let Err(err) = res {
                 error!("Error serving metrics connection: {err:#}");
             }
+        }
+        () = cancel.cancelled() => {
+            conn.as_mut().graceful_shutdown();
+            if let Err(err) = conn.await {
+                error!("Error during graceful metrics shutdown: {err:#}");
+            }
+        }
+    }
+}
+
+/// Periodic dumper that writes metrics as CSV rows to a file.
+///
+/// Aborts the background task on drop.
+#[derive(Debug)]
+pub struct MetricsDumper {
+    _task: AbortOnDropHandle<()>,
+}
+
+impl MetricsDumper {
+    /// Opens `path` for writing (truncating if it exists) and spawns the dumper.
+    ///
+    /// Each tick appends a row with the elapsed time and one column per metric.
+    pub async fn spawn(
+        path: std::path::PathBuf,
+        interval: Duration,
+        registry: impl MetricsSource,
+    ) -> Result<Self, Error> {
+        info!(file = %path.display(), ?interval, "running metrics dumper");
+        let file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&path)
+            .await?;
+        let task = tokio::spawn(async move {
+            let mut file = tokio::io::BufWriter::new(file);
+            let start = Instant::now();
+            let mut write_header = true;
+            loop {
+                let encoded = match registry.encode_openmetrics_to_string() {
+                    Ok(s) => s,
+                    Err(err) => {
+                        error!("metrics dumper failed: {err:#}");
+                        return;
+                    }
+                };
+                if let Err(err) = dump_metrics(&mut file, &start, &encoded, write_header).await {
+                    error!("metrics dumper failed: {err:#}");
+                    return;
+                }
+                if !write_header {
+                    tokio::time::sleep(interval).await;
+                }
+                write_header = false;
+            }
         });
+        Ok(Self {
+            _task: AbortOnDropHandle::new(task),
+        })
     }
 }
 
-/// Start a metrics dumper service.
-pub async fn start_metrics_dumper(
-    path: std::path::PathBuf,
-    interval: std::time::Duration,
-    registry: impl MetricsSource,
-) -> Result<(), crate::Error> {
-    info!(file = %path.display(), ?interval, "running metrics dumper");
+/// Periodic exporter that pushes metrics to a Prometheus push gateway.
+///
+/// Aborts the background task on drop.
+#[derive(Debug)]
+pub struct MetricsPushExporter {
+    _task: AbortOnDropHandle<()>,
+}
 
-    let start = Instant::now();
-
-    let file = tokio::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .open(&path)
-        .await?;
-
-    let mut file = tokio::io::BufWriter::new(file);
-
-    // Dump metrics once with a header
-    dump_metrics(&mut file, &start, &registry, true).await?;
-    loop {
-        dump_metrics(&mut file, &start, &registry, false).await?;
-        tokio::time::sleep(interval).await;
+impl MetricsPushExporter {
+    /// Spawns the push exporter in a background task.
+    pub fn spawn(cfg: MetricsExporterConfig, registry: impl MetricsSource) -> Self {
+        let task = tokio::spawn(exporter_loop(cfg, registry));
+        Self {
+            _task: AbortOnDropHandle::new(task),
+        }
     }
 }
 
-/// Start a metrics exporter service.
-pub async fn start_metrics_exporter(
-    cfg: MetricsExporterConfig,
-    registry: impl MetricsSource,
-) -> Result<(), Error> {
+async fn exporter_loop(cfg: MetricsExporterConfig, registry: impl MetricsSource) {
     let MetricsExporterConfig {
         interval,
         endpoint,
@@ -98,7 +219,13 @@ pub async fn start_metrics_exporter(
         format!("{endpoint}/metrics/job/{service_name}/instance/{instance_name}");
     loop {
         tokio::time::sleep(interval).await;
-        let buf = registry.encode_openmetrics_to_string()?;
+        let buf = match registry.encode_openmetrics_to_string() {
+            Ok(buf) => buf,
+            Err(err) => {
+                warn!("failed to encode metrics: {err:#}");
+                continue;
+            }
+        };
         let mut req = push_client.post(&prom_gateway_uri);
         if let Some(username) = username.clone() {
             req = req.basic_auth(username, Some(password.clone()));
@@ -123,7 +250,7 @@ pub async fn start_metrics_exporter(
     }
 }
 
-/// HTTP handler that will respond with the OpenMetrics encoding of our metrics.
+/// HTTP handler that responds with the OpenMetrics encoding of the metrics.
 #[allow(clippy::unused_async)]
 async fn handler(
     _req: Request<hyper::body::Incoming>,
@@ -147,11 +274,10 @@ fn body_full(content: impl Into<hyper::body::Bytes>) -> BytesBody {
 async fn dump_metrics(
     file: &mut tokio::io::BufWriter<tokio::fs::File>,
     start: &Instant,
-    registry: &impl MetricsSource,
+    encoded: &str,
     write_header: bool,
-) -> Result<(), Error> {
-    let m = registry.encode_openmetrics_to_string()?;
-    let m = parse_prometheus_metrics(&m);
+) -> std::io::Result<()> {
+    let m = parse_prometheus_metrics(encoded);
     let time_since_start = start.elapsed().as_millis() as f64;
 
     // take the keys from m and sort them

--- a/src/static_core.rs
+++ b/src/static_core.rs
@@ -6,7 +6,9 @@
 //! - To increment a **counter**, use the [`crate::inc`] macro with a value.
 //! - To increment a **counter** by 1, use the [`crate::inc_by`] macro.
 //!
-//! To expose the metrics, start the metrics service with `start_metrics_server()`.
+//! To expose the metrics, start the metrics service with [`MetricsServer::spawn`].
+//!
+//! [`MetricsServer::spawn`]: crate::service::MetricsServer::spawn
 //!
 //! # Example:
 //! ```rust

--- a/src/static_core.rs
+++ b/src/static_core.rs
@@ -6,9 +6,7 @@
 //! - To increment a **counter**, use the [`crate::inc`] macro with a value.
 //! - To increment a **counter** by 1, use the [`crate::inc_by`] macro.
 //!
-//! To expose the metrics, start the metrics service with [`MetricsServer::spawn`].
-//!
-//! [`MetricsServer::spawn`]: crate::service::MetricsServer::spawn
+//! To expose the metrics, start the metrics service from `crate::service`.
 //!
 //! # Example:
 //! ```rust


### PR DESCRIPTION
## Description

Refactors the services (HTTP server, HTTP pusher, file dumper) to return structs that stop the services when dropped.

## Breaking Changes

- removed: `iroh_metrics::service::start_metrics_server`, `iroh_metrics::service::start_metrics_dumper`, `iroh_metrics::service::start_metrics_exporter`.
- changed: `MetricsExporterConfig` no longer derives `PartialEq` or `Eq`, and gained a `tls_config: Option<rustls::ClientConfig>` field (struct-literal callers must add it).
- changed: TLS verification on the push gateway is now actually applied — previously `use_preconfigured_tls` received a half-built `ConfigBuilder` and silently fell back to reqwest's default TLS backend; the new code finalizes the config with `with_no_client_auth` so the platform certificate verifier is now in use.
- changed: errors from inside the server accept loop and the dumper write loop are now logged via `tracing` instead of returned to the caller (the new `spawn` constructors return after setup).
- added: `iroh_metrics::service::MetricsServer` (with `spawn`, `local_addr`, `shutdown`).
- added: `iroh_metrics::service::MetricsDumper` (with `spawn`, `shutdown`).
- added: `iroh_metrics::service::MetricsPushExporter` (with `spawn`, `shutdown`).
- added: `MetricsExporterConfig::tls_config`.


<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->
## Notes & open questions
<!-- Any notes, remarks or open questions you have to make about the PR. -->
## Change checklist
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.