### PR TITLE
fix: doc_auto_cfg is removed, it's now doc_cfg

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Metrics library for iroh
 
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
-#![cfg_attr(iroh_docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(iroh_docsrs, feature(doc_cfg))]
 
 pub use self::{
     base::*,


### PR DESCRIPTION
## Description

changes the docs attribute to document crate features to the correct one. otherwise fails to produce docs with recent nightlies.